### PR TITLE
Fixed Cannon color in Volcano Theme

### DIFF
--- a/Assets/Sprites/Blocks/Cannon.json
+++ b/Assets/Sprites/Blocks/Cannon.json
@@ -12,7 +12,7 @@
 		"Autumn": {"source": "Cannon.png", "rect": [0, 32, 48, 16]},
 		"Beach": {"source": "Cannon.png", "rect": [48, 32, 48, 16]},
 		"Mountain": {"source": "Cannon.png", "rect": [96, 32, 48, 16]},
-		"Volcano": {"source": "Cannon.png", "rect": [144, 32, 48, 16]},
+		"Volcano": {"source": "Cannon.png", "rect": [0, 32, 48, 16]},
 		"Bonus": {"source": "Cannon.png", "rect": [0, 48, 48, 16]}
 	}
 }


### PR DESCRIPTION
**What it does**
Fixes the coloring of the Cannon in the Volcano theme.

**Before Fix**

<img width="460" height="300" alt="image" src="https://github.com/user-attachments/assets/0b588a08-7530-4876-8328-01b6744e089d" />


**After Fix**

<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/c13360c5-1f9b-4e68-a90f-7c2e731e0794" />
