### PR TITLE
Fixed CastleWater BGOs via the .json

### DIFF
--- a/Assets/Sprites/Tilesets/Deco/DecoTiles.json
+++ b/Assets/Sprites/Tilesets/Deco/DecoTiles.json
@@ -158,16 +158,9 @@
 	  "SMBANN": { "source": "CastleDecoANN.png", "rect": [0.0, 0.0, 80.0, 32.0] }
 	},
 	"CastleWater": {
-	  "Day": {
-		"SMB1": { "source": "CastleWaterDeco.png", "rect": [0.0, 0.0, 80.0, 32.0] },
-		"SMBLL": { "source": "CastleWaterDecoLL.png", "rect": [0.0, 0.0, 80.0, 32.0] },
-		"SMBANN": { "source": "CastleWaterDecoANN.png", "rect": [0.0, 0.0, 80.0, 32.0] }
-	  },
-	  "Night": {
-		"SMB1": { "source": "CastleWaterDeco.png", "rect": [0.0, 32.0, 80.0, 32.0] },
-		"SMBLL": { "source": "CastleWaterDecoLL.png", "rect": [0.0, 32.0, 80.0, 32.0] },
-		"SMBANN": { "source": "CastleWaterDecoANN.png", "rect": [0.0, 32.0, 80.0, 32.0] }
-	  }
+	  "SMB1": { "source": "CastleWaterDeco.png", "rect": [0.0, 0.0, 80.0, 32.0] },
+	  "SMBLL": { "source": "CastleWaterLLDeco.png", "rect": [0.0, 0.0, 80.0, 32.0] },
+	  "SMBANN": { "source": "CastleWaterDecoANN.png", "rect": [0.0, 0.0, 80.0, 32.0] }
 	},
 	"Airship": {
 		"SMB1": {


### PR DESCRIPTION
Made two changes:
1) Removed day & night distinction, as separate day and night sprites don't exist (and probably shouldn't) 2) Fixed typo ("CastleWaterDecoLL" -> "CastleWaterLLDeco")