### PR TITLE
Coin Heaven Warps Player to The Right Spot

### DIFF
--- a/Scripts/Parts/CoinHeavenWarpPoint.gd
+++ b/Scripts/Parts/CoinHeavenWarpPoint.gd
@@ -5,9 +5,10 @@ extends Node2D
 
 func _ready() -> void:
 	Level.vine_warp_level = heaven_scene
-	Level.in_vine_level = false
-	if Level.in_vine_level and PipeArea.exiting_pipe_id == -1:
-		for i in get_tree().get_nodes_in_group("Players"):
-			i.global_position = global_position
-			i.reset_physics_interpolation()
-			i.recenter_camera()
+	if Level.in_vine_level:
+		Level.in_vine_level = false
+		if PipeArea.exiting_pipe_id == -1:
+			for i in get_tree().get_nodes_in_group("Players"):
+				i.global_position = global_position
+				i.reset_physics_interpolation()
+				i.recenter_camera()


### PR DESCRIPTION
Tweaks the code a bit for the Coin Heaven Warping so the Player isn't sent back to the beginning and to where the exit is.
Not sure what happened to be honest since I saw it work before.