### PR TITLE
Added Loop Points to Custom Levels Menu

### DIFF
--- a/Assets/Audio/BGM/CustomLevel.bgm
+++ b/Assets/Audio/BGM/CustomLevel.bgm
@@ -1,0 +1,10 @@
+{
+	"Normal": {
+		"source": "CustomLevel.mp3",
+		"loop": 4.8
+	},
+	"Hurry": {
+		"source": "CustomLevel.mp3",
+		"loop": 4.8
+	}
+}

--- a/Assets/Audio/BGM/CustomLevel.json
+++ b/Assets/Audio/BGM/CustomLevel.json
@@ -1,0 +1,5 @@
+{
+	"variations": {
+		"SMB1": {"source": "CustomLevel.bgm"}
+	}
+}

--- a/Scenes/Levels/CustomLevelMenu.tscn
+++ b/Scenes/Levels/CustomLevelMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=43 format=3 uid="uid://cyf16hyu7mr7x"]
+[gd_scene load_steps=41 format=3 uid="uid://cyf16hyu7mr7x"]
 
 [ext_resource type="Script" uid="uid://bxu6kcun4m6uo" path="res://Scripts/UI/CustomLevelMenu.gd" id="1_2wr4s"]
 [ext_resource type="Texture2D" uid="uid://bhuybr2gtuco5" path="res://Assets/Sprites/UI/MenuBG.png" id="2_0jssh"]
@@ -29,8 +29,7 @@
 [ext_resource type="Script" uid="uid://d63p6qr5a748" path="res://Scripts/UI/AutoScrollContainer.gd" id="24_wf6nb"]
 [ext_resource type="PackedScene" uid="uid://cr2pku7fjkgpo" path="res://Scenes/Prefabs/UI/OnlineLevelContainer.tscn" id="26_r5ajm"]
 [ext_resource type="PackedScene" uid="uid://ci678koo0peoa" path="res://Scenes/Prefabs/UI/CharacterSelect.tscn" id="28_u8fen"]
-[ext_resource type="Script" uid="uid://cq6f682453q6o" path="res://Scripts/Classes/Components/ResourceSetter.gd" id="29_ruj08"]
-[ext_resource type="Script" uid="uid://cmvlgsjmsk0v5" path="res://Scripts/Classes/Resources/ThemedResource.gd" id="30_gmv51"]
+[ext_resource type="JSON" path="res://Assets/Audio/BGM/CustomLevel.json" id="29_r5ajm"]
 
 [sub_resource type="Shader" id="Shader_u8fen"]
 code = "shader_type canvas_item;
@@ -87,11 +86,6 @@ region = Rect2(12, 0, 12, 12)
 
 [sub_resource type="StyleBoxLine" id="StyleBoxLine_obbrw"]
 color = Color(1, 1, 1, 1)
-
-[sub_resource type="Resource" id="Resource_qigcv"]
-script = ExtResource("30_gmv51")
-Overworld = ExtResource("23_22hnx")
-metadata/_custom_type_script = "uid://cmvlgsjmsk0v5"
 
 [node name="CustomLevelMenu" type="Node"]
 script = ExtResource("1_2wr4s")
@@ -368,11 +362,11 @@ layout_mode = 2
 focus_mode = 0
 
 [node name="ScrollContainer" parent="BG/Border/Levels/VBoxContainer/LevelInfo/SelectedLevel/MarginContainer/HBoxContainer/HSplitContainer/LeftHalf/LevelInfo" index="0"]
-scroll_horizontal = 288
+scroll_horizontal = 95
 is_active = true
 
 [node name="ScrollContainer2" parent="BG/Border/Levels/VBoxContainer/LevelInfo/SelectedLevel/MarginContainer/HBoxContainer/HSplitContainer/LeftHalf/LevelInfo" index="1"]
-scroll_horizontal = 6
+scroll_horizontal = 18
 is_active = true
 
 [node name="Panel" type="PanelContainer" parent="BG/Border/Levels/VBoxContainer/LevelInfo"]
@@ -383,7 +377,7 @@ theme_override_styles/panel = ExtResource("8_psbt7")
 [node name="AutoScrollContainer" type="ScrollContainer" parent="BG/Border/Levels/VBoxContainer/LevelInfo/Panel"]
 layout_mode = 2
 mouse_filter = 2
-scroll_vertical = 15
+scroll_vertical = 58
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 3
 script = ExtResource("24_wf6nb")
@@ -569,11 +563,12 @@ layout_mode = 2
 focus_mode = 0
 
 [node name="ScrollContainer" parent="BG/Border/Levels/VBoxContainer/LSSLevelInfo/SelectedOnlineLevel/MarginContainer/HBoxContainer/HSplitContainer/LeftHalf/LevelInfo" index="0"]
+scroll_horizontal = 66
 is_active = true
 auto_connect_focus = false
 
 [node name="ScrollContainer2" parent="BG/Border/Levels/VBoxContainer/LSSLevelInfo/SelectedOnlineLevel/MarginContainer/HBoxContainer/HSplitContainer/LeftHalf/LevelInfo" index="1"]
-scroll_horizontal = 6
+scroll_horizontal = 18
 is_active = true
 auto_connect_focus = false
 
@@ -586,7 +581,7 @@ theme_override_styles/panel = ExtResource("8_psbt7")
 [node name="AutoScrollContainer" type="ScrollContainer" parent="BG/Border/Levels/VBoxContainer/LSSLevelInfo/Panel"]
 layout_mode = 2
 mouse_filter = 0
-scroll_vertical = 15
+scroll_vertical = 58
 horizontal_scroll_mode = 3
 script = ExtResource("24_wf6nb")
 direction = 1
@@ -649,15 +644,15 @@ metadata/_custom_type_script = "uid://co6tjg3w6qpd8"
 
 [node name="BGM" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("23_22hnx")
-autoplay = true
 bus = &"Music"
 
-[node name="ResourceSetter" type="Node" parent="BGM" node_paths=PackedStringArray("node_to_affect")]
-script = ExtResource("29_ruj08")
+[node name="ResourceSetterNew" type="Node" parent="BGM" node_paths=PackedStringArray("node_to_affect")]
+script = ExtResource("14_tjro6")
 node_to_affect = NodePath("..")
 property_name = "stream"
-themed_resource = SubResource("Resource_qigcv")
-metadata/_custom_type_script = "uid://cq6f682453q6o"
+mode = 2
+resource_json = ExtResource("29_r5ajm")
+metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
 [node name="CharacterSelect" parent="." instance=ExtResource("28_u8fen")]
 visible = false
@@ -702,7 +697,7 @@ focus_mode = 2
 [connection signal="pressed" from="BG/Border/Levels/VBoxContainer/LSSLevelInfo/HBoxContainer/ViewOnLSS" to="BG/Border/Levels/VBoxContainer/LSSLevelInfo" method="open_lss"]
 [connection signal="request_completed" from="BG/Border/Levels/VBoxContainer/LSSLevelInfo/Description" to="BG/Border/Levels/VBoxContainer/LSSLevelInfo" method="on_request_completed"]
 [connection signal="request_completed" from="BG/Border/Levels/VBoxContainer/LSSLevelInfo/DownloadLevel" to="BG/Border/Levels/VBoxContainer/LSSLevelInfo" method="level_downloaded"]
-[connection signal="sprites_updated" from="BGM/ResourceSetter" to="BGM" method="play"]
+[connection signal="updated" from="BGM/ResourceSetterNew" to="BGM" method="play"]
 [connection signal="cancelled" from="CharacterSelect" to="BG/Border/Levels/VBoxContainer/LevelInfo" method="reopen"]
 
 [editable path="BG/Border/Levels/VBoxContainer/LevelInfo/SelectedLevel"]


### PR DESCRIPTION
I'm gonna be honest, I forgot about this one. Like, I saw that CustomLevel.mp3 needed to be looped like SMB Deluxe but I forgot about it until now.
This also updates the ResourceSetter for this menu's BGM from the old version to the new one so it can use the JSON and BGM formats.

https://github.com/user-attachments/assets/b1714488-76f9-4dcf-850f-0fa2bce44c6c

