### PR TITLE
Re-Opened the Minus World

### DIFF
--- a/Scenes/Parts/Tiles.tscn
+++ b/Scenes/Parts/Tiles.tscn
@@ -1786,6 +1786,7 @@ func _ready() -> void:
 		tile_map.set_cell(i, -1)
 		var node = BRICK_BLOCK.instantiate()
 		node.global_position = (i * Vector2i(16, 16) + Vector2i(8, 8)) + Vector2i(tile_map.global_position)
+		node.get_node(\"Collision\").disabled = !tile_map.collision_enabled
 		add_child(node)
 "
 


### PR DESCRIPTION
Not sure how this bug happened since it worked before.

This adds a check for Brick Blocks. If its parent TileMap collision is disabled, the Brick Blocks' collision is also disabled. This allows the user to enter the Minus World as it would be blocked off otherwise.

https://github.com/user-attachments/assets/1282b5e4-c282-466f-bdc4-c800fb1c8f86


