### PR TITLE
Title Screen QOL Theming

### DIFF
--- a/Assets/Sprites/UI/TitleScreenStars.json
+++ b/Assets/Sprites/UI/TitleScreenStars.json
@@ -92,6 +92,6 @@
 		"Castle": {"source": "TitleScreenStars.png", "rect": [0, 16, 24, 8]},
 		"Snow": {"source": "TitleScreenStars.png", "rect": [0, 24, 24, 8]},
 		"Space": {"source": "TitleScreenStars.png", "rect": [0, 32, 24, 8]},
-		"Volcano": {"source": "TitleScreenStars.png", "rect": [0, 48, 24, 8]}
+		"Volcano": {"source": "TitleScreenStars.png", "rect": [0, 40, 24, 8]}
 	}
 }

--- a/Scripts/Classes/LevelClass.gd
+++ b/Scripts/Classes/LevelClass.gd
@@ -9,6 +9,13 @@ extends Node
 
 const THEME_IDXS := ["Overworld", "Underground", "Desert", "Snow", "Jungle", "Beach", "Garden", "Mountain", "Skyland", "Autumn", "Pipeland", "Space", "Underwater", "Volcano", "GhostHouse", "Castle", "CastleWater", "Airship", "Bonus"]
 
+const WORLD_COUNTS := {
+	"SMB1": 8,
+	"SMBLL": 13,
+	"SMBS": 8,
+	"SMBANN": 8
+}
+
 const WORLD_THEMES := {
 	"SMB1": SMB1_THEMES,
 	"SMBLL": SMB1_THEMES,
@@ -29,6 +36,8 @@ const SMB1_THEMES := {
 	9: "Space",
 	10: "Autumn",
 	11: "Pipeland",
+	12: "Skyland",
+	13: "Volcano"
 }
 
 const SMBS_THEMES := {
@@ -130,6 +139,9 @@ func update_next_level_info() -> void:
 
 static func get_scene_string(world_num := 0, level_num := 0) -> String:
 	return "res://Scenes/Levels/" + Global.current_campaign + "/World" + str(world_num) + "/" + str(world_num) + "-" + str(level_num) + ".tscn"
+
+static func get_world_count() -> int:
+	return WORLD_COUNTS[Global.current_campaign]
 
 func transition_to_next_level() -> void:
 	if Global.current_game_mode == Global.GameMode.CHALLENGE:

--- a/Scripts/Classes/Singletons/SaveManager.gd
+++ b/Scripts/Classes/Singletons/SaveManager.gd
@@ -113,7 +113,7 @@ func write_save_to_file(json := {}, path := "") -> void:
 	file.close()
 
 func apply_save(json := {}) -> void:
-	Global.world_num = clamp(json["World"], 1, 8)
+	Global.world_num = json.get_or_add("World", 1)
 	Global.level_num = json.get_or_add("Level", 1)
 	Global.lives = json["Lives"]
 	Global.coins = json["Coins"]

--- a/Scripts/UI/TitleScreenOptions.gd
+++ b/Scripts/UI/TitleScreenOptions.gd
@@ -21,7 +21,7 @@ func _process(_delta: float) -> void:
 		handle_inputs()
 
 func open() -> void:
-	Global.world_num = clamp(Global.world_num, 1, 8) # have this, cause i cba to make a fix for backing out of world 9 keeping you at world 9
+	Global.world_num = clamp(Global.world_num, 1, Level.get_world_count())
 	title_screen_parent.active_options = self
 	show()
 	await get_tree().physics_frame

--- a/Scripts/UI/WorldSelect.gd
+++ b/Scripts/UI/WorldSelect.gd
@@ -92,9 +92,9 @@ func cleanup() -> void:
 	await get_tree().physics_frame
 	Global.world_num = starting_value
 	starting_value = -1
-	Global.world_num = clamp(Global.world_num, 1, 8)
+	Global.world_num = clamp(Global.world_num, 1, Level.get_world_count())
 	if owner is Level:
-		owner.world_id = clamp(owner.world_id, 1, 8)
+		owner.world_id = clamp(owner.world_id, 1, Level.get_world_count())
 
 func close() -> void:
 	active = false


### PR DESCRIPTION
This was supposed to be a quick quality of life addition for the Title Screen that applied the save and theme to the menu, but then I discovered a new bug I had to bypass with the character palette when doing it. So, I ended up doing a bit more related to the Title Screen as a result.

I also *had* a function which checks for the number of valid folders within the Pck to see how many worlds there are, but I think it might've been a bit slow, so I replaced it with constant values of how many worlds there are in each campaign.

https://github.com/user-attachments/assets/27d18a5c-1bc2-45d6-87ab-ff27abf7f22f

- Save for the currently loaded campaign gets applied on startup
- Backing out of World 9 and over keeps you on said worlds at the title screen
- Added Skyland and Volcano to SMB1 themes since it shares most of its themes with Lost Levels
- Fixed Title Screen Stars not appearing for the Volcano Theme