### PR TITLE
Barrel And Muncher Fix

### DIFF
--- a/Scenes/Prefabs/Entities/Enemies/Barrel.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/Barrel.tscn
@@ -39,7 +39,7 @@ animations = [{
 size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_m378g"]
-size = Vector2(9, 8)
+size = Vector2(10, 6)
 
 [node name="Barrel" type="CharacterBody2D" node_paths=PackedStringArray("on_screen_enabler", "score_note_adder") groups=["Enemies"]]
 collision_layer = 16
@@ -79,7 +79,7 @@ shape = SubResource("RectangleShape2D_7nplu")
 collision_mask = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hitbox"]
-position = Vector2(-0.5, -8)
+position = Vector2(0, -9)
 shape = SubResource("RectangleShape2D_m378g")
 
 [node name="EnemyPlayerDetection" type="Node" parent="." node_paths=PackedStringArray("hitbox")]
@@ -113,8 +113,8 @@ metadata/_custom_type_script = "uid://cmg61722ktg2m"
 script = ExtResource("12_d7wml")
 hitbox = NodePath("../Hitbox")
 
-[connection signal="invincible_player_hit" from="EnemyPlayerDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="invincible_player_hit" from="EnemyPlayerDetection" to="." method="destroy" unbinds=1]
+[connection signal="invincible_player_hit" from="EnemyPlayerDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="player_hit" from="EnemyPlayerDetection" to="." method="damage_player"]
 [connection signal="player_stomped_on" from="EnemyPlayerDetection" to="." method="damage_player"]
 [connection signal="explosion_entered" from="ExplosionDetection" to="." method="die_from_object"]

--- a/Scenes/Prefabs/Entities/Enemies/Muncher.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/Muncher.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bi1hb03wk001p"]
+[gd_scene load_steps=17 format=3 uid="uid://bi1hb03wk001p"]
 
 [ext_resource type="Script" uid="uid://bpydbpyjk1mt4" path="res://Scripts/Classes/Entities/Enemy.gd" id="1_cgdwi"]
 [ext_resource type="Texture2D" uid="uid://dg7yxoq44gaae" path="res://Assets/Sprites/Enemies/Muncher.png" id="2_ad4wf"]
@@ -32,7 +32,13 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cgdwi"]
-size = Vector2(15.9, 16)
+size = Vector2(14, 16)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6gi78"]
+size = Vector2(14, 14)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_sjn4g"]
+size = Vector2(14, 14)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_r7ue2"]
 size = Vector2(17, 18.5)
@@ -42,8 +48,8 @@ size = Vector2(16, 16)
 
 [node name="Muncher" type="CharacterBody2D" node_paths=PackedStringArray("on_screen_enabler", "score_note_adder") groups=["Enemies"]]
 disable_mode = 1
-collision_layer = 20
-collision_mask = 4114
+collision_layer = 54
+collision_mask = 4098
 script = ExtResource("1_cgdwi")
 on_screen_enabler = NodePath("VisibleOnScreenEnabler2D")
 score_note_adder = NodePath("ScoreNoteSpawner")
@@ -65,8 +71,18 @@ property_name = "sprite_frames"
 resource_json = ExtResource("5_cgdwi")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
-[node name="Collision" type="CollisionShape2D" parent="."]
+[node name="DCollision" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_cgdwi")
+one_way_collision = true
+
+[node name="RCollision" type="CollisionShape2D" parent="."]
+rotation = -1.5707964
+shape = SubResource("RectangleShape2D_6gi78")
+one_way_collision = true
+
+[node name="LCollision" type="CollisionShape2D" parent="."]
+rotation = 1.5707964
+shape = SubResource("RectangleShape2D_sjn4g")
 one_way_collision = true
 
 [node name="PlayerDetection" type="Area2D" parent="."]

--- a/Scripts/Classes/Entities/Enemies/Barrel.gd
+++ b/Scripts/Classes/Entities/Enemies/Barrel.gd
@@ -5,7 +5,7 @@ const BARREL_DESTRUCTION_PARTICLE = preload("res://Scenes/Prefabs/Particles/Barr
 func _physics_process(delta: float) -> void:
 	handle_movement(delta)
 
-func handle_movement(delta: float) -> void:
+func handle_movement(_delta: float) -> void:
 	if is_on_wall() and is_on_floor() and get_wall_normal().x == -direction:
 		die()
 


### PR DESCRIPTION
Adjusted Barrel's hitbox sizes along with Muncher's collision functionalities to be more suited for user-made contraptions. Muncher now uses three one-way collisions instead of just one.