### PR TITLE
Fix for small custom chararacters being unable to enter sideways underwater pipes

### DIFF
--- a/Scripts/Classes/Entities/PipeArea.gd
+++ b/Scripts/Classes/Entities/PipeArea.gd
@@ -102,8 +102,8 @@ func in_game() -> void:
 			run_player_check(i.owner)
 
 func run_player_check(player: Player) -> void:
-	if Global.player_action_pressed(get_input_direction(enter_direction), player.player_id) and can_enter and (player.is_on_floor() or enter_direction == 1 or player.gravity_vector != Vector2.DOWN) and player.state_machine.state.name == "Normal":
-		can_enter = false
+	# guzlad: Added support for characters with a hitbox height below 1.0 to enter pipes underwater
+	if Global.player_action_pressed(get_input_direction(enter_direction), player.player_id) and can_enter and (player.is_on_floor() or enter_direction == 1 or player.gravity_vector != Vector2.DOWN or (!player.is_on_floor() and enter_direction == 3)) and player.state_machine.state.name == "Normal":		can_enter = false
 		pipe_entered.emit()
 		DiscoLevel.can_meter_tick = false
 		Level.in_vine_level = false


### PR DESCRIPTION
This fixes characters with a hitbox height below 1.0 not being able to enter sideways underwater pipes and causing a softlock.
It's done by changing a statement in the "run_player_check" function to allow characters which are both in the air and moving right to enter the pipe.