### PR TITLE
Special Castle in Level Editor

### DIFF
--- a/Scenes/Prefabs/LevelObjects/EndFinalCastle.tscn
+++ b/Scenes/Prefabs/LevelObjects/EndFinalCastle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=4 uid="uid://bney0cc8cfm5s"]
+[gd_scene load_steps=20 format=4 uid="uid://bney0cc8cfm5s"]
 
 [ext_resource type="Script" uid="uid://qq26qw7ltflb" path="res://Scripts/Parts/EndCastle.gd" id="1_hwcne"]
 [ext_resource type="Script" uid="uid://caq1qiwmy0mox" path="res://Scripts/Parts/BetterAnimatedSprite.gd" id="2_1kswc"]
@@ -7,6 +7,7 @@
 [ext_resource type="JSON" path="res://Assets/Sprites/Tilesets/CastleFlag.json" id="4_wqi45"]
 [ext_resource type="PackedScene" uid="uid://bikdod5ra10ra" path="res://Scenes/Parts/LargeCastleVisual.tscn" id="6_w7qld"]
 [ext_resource type="Script" uid="uid://73oviwf6bbys" path="res://Scripts/Classes/Components/TilesetTextureSetter.gd" id="8_akqko"]
+[ext_resource type="PackedScene" uid="uid://bem5ht17ukgcs" path="res://Scenes/Parts/LargeSPCastleVisual.tscn" id="10_kd4m5"]
 [ext_resource type="Texture2D" uid="uid://dt0qtxu2l646n" path="res://Assets/Sprites/Tilesets/Terrain/Overworld.png" id="10_wqi45"]
 [ext_resource type="Texture2D" uid="uid://dkcs5i8l1y4y6" path="res://Assets/Sprites/Tilesets/EndingFinalCastleSprite.png" id="11_wqi45"]
 [ext_resource type="JSON" path="res://Assets/Sprites/Tilesets/FinalCastle.json" id="12_kd4m5"]
@@ -117,6 +118,10 @@ autostart = true
 [node name="SmallCastleVisual" parent="." instance=ExtResource("6_w7qld")]
 z_index = -10
 position = Vector2(0, -40)
+
+[node name="SmallCastleVisual2" parent="." instance=ExtResource("10_kd4m5")]
+visible = false
+position = Vector2(32, -40)
 
 [node name="OverlaySprite" type="Sprite2D" parent="."]
 visible = false

--- a/Scenes/Prefabs/LevelObjects/EndFinalSpCastle.tscn
+++ b/Scenes/Prefabs/LevelObjects/EndFinalSpCastle.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=6 format=3 uid="uid://b5o0j3kfv2xys"]
+[gd_scene load_steps=5 format=3 uid="uid://b5o0j3kfv2xys"]
 
 [ext_resource type="PackedScene" uid="uid://bney0cc8cfm5s" path="res://Scenes/Prefabs/LevelObjects/EndFinalCastle.tscn" id="1_fa5ur"]
-[ext_resource type="PackedScene" uid="uid://bem5ht17ukgcs" path="res://Scenes/Parts/LargeSPCastleVisual.tscn" id="2_jlw6s"]
 [ext_resource type="Texture2D" uid="uid://gnqt7rl36kxy" path="res://Assets/Sprites/Tilesets/CastleFlag.png" id="2_jp1ee"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_uq0jd"]
@@ -29,8 +28,8 @@ do_offset = false
 [node name="SmallCastleVisual" parent="." index="3"]
 visible = false
 
-[node name="SmallCastleVisual2" parent="." index="6" instance=ExtResource("2_jlw6s")]
-position = Vector2(32, -40)
+[node name="SmallCastleVisual2" parent="." index="4"]
+visible = true
 
 [node name="Overlay" parent="." index="7"]
 visible = true

--- a/Scripts/Parts/EndCastle.gd
+++ b/Scripts/Parts/EndCastle.gd
@@ -32,6 +32,10 @@ func update_cam_limit() -> void:
 
 func _process(_delta: float) -> void:
 	$Overlay.modulate.a = int($SmallCastleVisual.use_sprite == false)
+	if Global.level_editor != null && scene_file_path == "res://Scenes/Prefabs/LevelObjects/EndFinalCastle.tscn":
+		var is_smbs: bool = Global.current_campaign == "SMBS"
+		$SmallCastleVisual.visible = !is_smbs
+		$SmallCastleVisual2.visible = is_smbs
 	if get_node_or_null("Wall") != null:
 		%Wall.visible = show_walls
 


### PR DESCRIPTION
This PR changes the End Final Castle to use the Special visuals when the level is in the SMBS campaign.

This is primarily for the Level Editor / Custom Levels and isn't really necessary for the main campaigns. Hence the added check to make sure the Level Editor / Custom Level is in use.

<img width="1280" alt="SMB1" src="https://github.com/user-attachments/assets/98412f9e-ede6-454f-a808-8b9bf6effeaf" />
<img width="1280" alt="Special" src="https://github.com/user-attachments/assets/7cd56436-39d2-4d76-bb77-91d4fd3b76a6" />
