### PR TITLE
Nerfed SMBLL YvB 2-4's Gold Boo by 1 second

### DIFF
--- a/Scenes/Levels/SMBLL/YouVSBoo/Boo2-4.tscn
+++ b/Scenes/Levels/SMBLL/YouVSBoo/Boo2-4.tscn
@@ -190,7 +190,7 @@ level_id = 7
 [node name="RaceBoo" parent="." node_paths=PackedStringArray("path") instance=ExtResource("16_fhj5s")]
 position = Vector2(-248, -136)
 path = NodePath("../Path2D/PathFollow2D")
-time_needed = [65, 60, 55, 50, 44]
+time_needed = [65, 60, 55, 50, 45]
 
 [node name="Path2D" type="Path2D" parent="."]
 curve = SubResource("Curve2D_2v8ni")


### PR DESCRIPTION
Currently, 2-4's Gold Boo time is incredibly tight, much more so than other Gold Boo times. This is to the point where the room for error is noticeably slim, so nerfing the Gold Boo time by just a single second aims to add some leeway, even if it's minor.