### PR TITLE
Updated Red Coins and Coin Sparkle

### DIFF
--- a/Assets/Sprites/Items/Coin.json
+++ b/Assets/Sprites/Items/Coin.json
@@ -85,6 +85,9 @@
 			"loop": true
 		}
 	},
+	"properties": {
+		"can_spawn_particles": true
+	},
 	"variations": {
 		"default": {"source": "StaticCoin.png", "rect": [0, 0, 64, 16]},
 		"Underground": {"source": "StaticCoin.png", "rect": [0, 16, 64, 16]},

--- a/Assets/Sprites/Items/SpinningCoin.json
+++ b/Assets/Sprites/Items/SpinningCoin.json
@@ -31,6 +31,9 @@
 			"loop": true
 		}
 	},
+	"properties": {
+		"can_spawn_particles": true
+	},
 	"variations": {
 		"default": {
 			"source": "SpinningCoin.png",

--- a/Assets/Sprites/Particles/CoinSparkle.json
+++ b/Assets/Sprites/Particles/CoinSparkle.json
@@ -1,0 +1,10 @@
+{
+	"properties": {
+		"amount": 3,
+		"process_material.emission_shape": 1,
+		"material.particles_anim_h_frames": 8
+	},
+	"variations": {
+		"default": {"source": "CoinSparkle.png", "rect": [0, 0, 64, 8]}
+	}
+}

--- a/Scenes/Prefabs/Entities/Items/Coin.tscn
+++ b/Scenes/Prefabs/Entities/Items/Coin.tscn
@@ -62,9 +62,10 @@ sprite_frames = SubResource("SpriteFrames_nu35s")
 autoplay = "default"
 frame_progress = 0.487032
 
-[node name="ResourceSetterNew" type="Node" parent="Sprite" node_paths=PackedStringArray("node_to_affect")]
+[node name="ResourceSetterNew" type="Node" parent="Sprite" node_paths=PackedStringArray("node_to_affect", "property_node")]
 script = ExtResource("3_uahob")
 node_to_affect = NodePath("..")
+property_node = NodePath("../..")
 property_name = "sprite_frames"
 resource_json = ExtResource("4_thymr")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"

--- a/Scenes/Prefabs/Entities/Items/SpinningCoin.tscn
+++ b/Scenes/Prefabs/Entities/Items/SpinningCoin.tscn
@@ -51,9 +51,10 @@ sprite_frames = SubResource("SpriteFrames_sax2u")
 autoplay = "default"
 frame_progress = 0.710764
 
-[node name="ResourceSetterNew" type="Node" parent="Sprite" node_paths=PackedStringArray("node_to_affect")]
+[node name="ResourceSetterNew" type="Node" parent="Sprite" node_paths=PackedStringArray("node_to_affect", "property_node")]
 script = ExtResource("3_7mdmn")
 node_to_affect = NodePath("..")
+property_node = NodePath("../..")
 property_name = "sprite_frames"
 resource_json = ExtResource("4_b5lmc")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"

--- a/Scenes/Prefabs/Particles/CoinSparkle.tscn
+++ b/Scenes/Prefabs/Particles/CoinSparkle.tscn
@@ -1,4 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://b1ytbn4cu7msu"]
+[gd_scene load_steps=6 format=3 uid="uid://b1ytbn4cu7msu"]
+
+[ext_resource type="Texture2D" uid="uid://dkebo0uw0dkkw" path="res://Assets/Sprites/Particles/CoinSparkle.png" id="1_0guw6"]
+[ext_resource type="Script" uid="uid://cbal8ms2oe1ik" path="res://Scripts/Classes/Components/ResourceSetterNew.gd" id="2_wdqt2"]
+[ext_resource type="JSON" path="res://Assets/Sprites/Particles/CoinSparkle.json" id="3_wdqt2"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_0guw6"]
 particles_animation = true
@@ -18,6 +22,7 @@ anim_speed_max = 2.0
 material = SubResource("CanvasItemMaterial_0guw6")
 emitting = false
 amount = 3
+texture = ExtResource("1_0guw6")
 lifetime = 0.5
 one_shot = true
 explosiveness = 0.7
@@ -25,8 +30,13 @@ interpolate = false
 fract_delta = false
 process_material = SubResource("ParticleProcessMaterial_wdqt2")
 
-[node name="Timer" type="Timer" parent="."]
-autostart = true
+[node name="ResourceSetterNew" type="Node" parent="." node_paths=PackedStringArray("node_to_affect", "property_node")]
+script = ExtResource("2_wdqt2")
+node_to_affect = NodePath("..")
+property_node = NodePath("..")
+property_name = "texture"
+mode = 1
+resource_json = ExtResource("3_wdqt2")
+metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
 [connection signal="ready" from="." to="." method="set_emitting" binds= [true]]
-[connection signal="timeout" from="Timer" to="." method="queue_free"]

--- a/Scripts/Classes/Blocks/BrickBlock.gd
+++ b/Scripts/Classes/Blocks/BrickBlock.gd
@@ -1,7 +1,7 @@
 class_name BrickBlock
 extends Block
 
-var ticking_down := false
+var times_hit := 0
 
 func _ready() -> void:
 	if item_amount == 10 and item.resource_path == "res://Scenes/Prefabs/Entities/Items/SpinningCoin.tscn" and is_instance_valid(Global.level_editor) == false:
@@ -11,6 +11,7 @@ func check_brick_empty() -> void:
 	$PSwitcher.enabled = item == null
 
 func on_block_hit(player: Player) -> void:
+	times_hit += 1
 	if player.power_state.hitbox_size == "Big":
 		if item == null:
 			await get_tree().physics_frame
@@ -30,4 +31,6 @@ func on_shell_block_hit(_shell: Shell) -> void:
 		dispense_item()
 
 func set_coin_count() -> void:
-	item_amount = 2
+	if times_hit >= 9 and Global.current_game_mode == Global.GameMode.CHALLENGE:
+		item = load("res://Scenes/Prefabs/Entities/Items/SpinningRedCoin.tscn")
+	item_amount = 1

--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -158,7 +158,16 @@ func apply_properties(properties := {}) -> void:
 	if property_node == null:
 		return
 	for i in properties.keys():
-		property_node.set(i, properties[i])
+		var obj = property_node
+		for p in i.split("."):
+			if not is_instance_valid(obj): continue
+			if obj.get(p) is Object:
+				if obj.has_method("duplicate"):
+					obj.set(p, obj[p].duplicate(true))
+				obj = obj[p]
+			else:
+				obj.set(p, properties[i])
+				continue
 
 func get_variation_json(json := {}) -> Dictionary:
 	var level_theme = Global.level_theme

--- a/Scripts/Classes/Entities/Items/Coin.gd
+++ b/Scripts/Classes/Entities/Items/Coin.gd
@@ -3,6 +3,8 @@ const COIN_SPARKLE = preload("res://Scenes/Prefabs/Particles/CoinSparkle.tscn")
 
 @export var spinning_coin_scene: PackedScene = null
 
+var can_spawn_particles := true
+
 signal collected
 
 func area_entered(area: Area2D) -> void:
@@ -11,11 +13,16 @@ func area_entered(area: Area2D) -> void:
 
 func collect() -> void:
 	collected.emit()
+	$Hitbox.area_entered.disconnect(area_entered)
 	Global.coins += 1
 	DiscoLevel.combo_meter += 10
 	Global.score += 200
 	AudioManager.play_sfx("coin", global_position)
-	queue_free()
+	if can_spawn_particles:
+		summon_particle()
+		$Sprite.queue_free()
+	else:
+		queue_free()
 
 func summon_block_coin() -> void:
 	var node = spinning_coin_scene.instantiate()
@@ -25,5 +32,5 @@ func summon_block_coin() -> void:
 
 func summon_particle() -> void:
 	var node = COIN_SPARKLE.instantiate()
-	node.global_position = global_position
-	add_sibling(node)
+	node.finished.connect(queue_free)
+	add_child(node)

--- a/Scripts/Classes/Entities/Items/SpinningCoin.gd
+++ b/Scripts/Classes/Entities/Items/SpinningCoin.gd
@@ -2,19 +2,26 @@ extends Node2D
 const COIN_SPARKLE = preload("res://Scenes/Prefabs/Particles/CoinSparkle.tscn")
 var velocity := Vector2(0, -300)
 
+var can_spawn_particles := true
+
 func _ready() -> void:
 	Global.coins += 1
 	Global.score += 200
 	AudioManager.play_sfx("coin", global_position)
 
 func _physics_process(delta: float) -> void:
-	global_position += velocity * delta
-	velocity.y += (15 / delta) * delta
+	if get_node_or_null("Sprite") != null:
+		global_position += velocity * delta
+		velocity.y += (15 / delta) * delta
 
 func vanish() -> void:
-	queue_free()
+	if can_spawn_particles:
+		summon_particle()
+		$Sprite.queue_free()
+	else:
+		queue_free()
 
 func summon_particle() -> void:
 	var node = COIN_SPARKLE.instantiate()
-	node.global_position = global_position
-	add_sibling(node)
+	node.finished.connect(queue_free)
+	add_child(node)


### PR DESCRIPTION
Was making my rounds with tweaking the Levels with Level Maps from Mario Universe and TMK, but I made a detour to mess with the money. This PR adds the unused Coin sparkle effects to regular coins and adjusts the conditions of the Red Coin. I also expanded the `ResourceSetterNew` class to check for properties that are Objects which can be recursively edited with the identifier ".", primarily for the ability to make the graphics accurate to SMAS. Let me know if you prefer the sparkling to be off by default on either or both.

https://github.com/user-attachments/assets/b8e969ac-9a07-4ccf-81c1-cb12e4890999

https://github.com/user-attachments/assets/abadc31d-f308-4b98-97d7-4ed46a2e5dc5

NOTE: In SMB Deluxe, the Red Coin appears *exactly* on the 10th hit of a Coin Brick Block, but I decided to have it appear after you hit the block 10 times or over to be looser and to rack up more score. Also, I realize after I committed that I should've split these into two different branches. So, if you want me to redo this and split this PR into two, let me know.
- Adjust `ResourceSetterNew` so it can also affect properties that are Objects (recursive property changing basically)
- Added Coin Sparkle on by default for Coins in Blocks or floating in the Level. Can be affected by Resource Packs and JSON changes
- When hitting a Coin Brick Block after some time, it produces 1 coin after hitting again instead of 2
- The Red Coin will only pop out of Coin Brick Blocks after being hit at least 9 times prior to the timeout. On the 10th hit or greater, the coin will pop out.