### PR TITLE
Removed firebar 45 degree steps, raised limit from 16 to 18

### DIFF
--- a/Scenes/Prefabs/Entities/Objects/Firebar.tscn
+++ b/Scenes/Prefabs/Entities/Objects/Firebar.tscn
@@ -13,9 +13,10 @@
 [sub_resource type="GDScript" id="GDScript_e2e05"]
 script/source = "extends Node2D
 
-@export_range(4, 16) var length := 6
+# guzlad: Changed from 16 to 18 to mimick SMM
+@export_range(4, 18) var length := 6
 
-@export_range(0, 360, 45) var starting_angle := 0
+@export_range(0, 360) var starting_angle := 0
 
 @export_enum(\"C-Clockwise\", \"Clockwise\") var direction := 0
 


### PR DESCRIPTION
The max length of the firebar has been raised from 16 to 18 to match SMM.
The 45 degree steps between 0 and 360 when picking a starting rotation have also been removed due to the requests of some level creators.

This fixes this issue https://github.com/JHDev2006/Super-Mario-Bros.-Remastered-Public/issues/318