### PR TITLE
Doors and Key Fixes

### DIFF
--- a/Scripts/Classes/Editor/LevelEditor.gd
+++ b/Scripts/Classes/Editor/LevelEditor.gd
@@ -294,6 +294,8 @@ func return_to_editor() -> void:
 	return_editor_tiles()
 	%Camera.enabled = true
 	%Camera.make_current()
+	KeyItem.total_collected = 0
+	Door.unlocked_doors.clear()
 	editor_start.emit()
 	current_state = EditorState.IDLE
 	handle_hud()

--- a/Scripts/Classes/Entities/Objects/Door.gd
+++ b/Scripts/Classes/Entities/Objects/Door.gd
@@ -87,6 +87,7 @@ func player_exit(player: Player) -> void:
 	exiting_door_id = -1
 	can_enter = false
 	LevelEditor.play_door_transition = false
+	if same_scene_exiting_door != null: same_scene_exiting_door.get_node("Sprite").play("Idle")
 	same_scene_exiting_door = null
 	player.global_position = global_position
 	player.recenter_camera()


### PR DESCRIPTION
This fixes the Door animation so that when you enter a door and exit around the same general area, the door you entered from closes automatically. Also added some fixes for the Level Editor where after leaving the playtest mode, the number of keys you have resets to 0 and the locked doors re-lock.

https://github.com/user-attachments/assets/3782614c-ac99-4fc2-856f-2b47f34657c6

