### PR TITLE
Hitbox Change for When Small and Crouching

### DIFF
--- a/Scenes/Prefabs/Entities/Player.tscn
+++ b/Scenes/Prefabs/Entities/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=83 format=3 uid="uid://cuh62hlq8errh"]
+[gd_scene load_steps=84 format=3 uid="uid://cuh62hlq8errh"]
 
 [ext_resource type="Script" uid="uid://dt4rosa5o35xr" path="res://Scripts/Classes/Entities/Player.gd" id="1_f6bau"]
 [ext_resource type="Script" uid="uid://uribh0f1jttq" path="res://Scripts/Classes/States/StateMachine.gd" id="2_1y62l"]
@@ -468,6 +468,10 @@ func _physics_process(_delta: float) -> void:
 			owner.recenter_camera()
 			print(Global.level_editor.entity_tiles)
 "
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_fqdtv"]
+resource_local_to_scene = true
+size = Vector2(4, 4.5)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_d7xah"]
 resource_local_to_scene = true
@@ -1039,6 +1043,12 @@ mode = 1
 resource_json = ExtResource("10_xy8gq")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
+[node name="CrouchCollision" type="CollisionPolygon2D" parent="." groups=["SmallCollisions"]]
+visible = false
+polygon = PackedVector2Array(4, -2, 4, -8, 1, -11, -1, -11, -4, -8, -4, -2, -2, 0, 2, 0)
+one_way_collision = true
+script = ExtResource("35_nbkfn")
+
 [node name="SmallCollision" type="CollisionPolygon2D" parent="." groups=["SmallCollisions"]]
 polygon = PackedVector2Array(4, -2, 4, -8, 1, -14, -1, -14, -4, -8, -4, -2, -2, 0, 2, 0)
 one_way_collision = true
@@ -1089,6 +1099,15 @@ hit_from_inside = true
 [node name="BlockCollision" type="Area2D" parent="."]
 collision_layer = 0
 collision_mask = 4
+
+[node name="CrouchShape" type="CollisionShape2D" parent="BlockCollision" node_paths=PackedStringArray("link") groups=["SmallCollisions"]]
+visible = false
+position = Vector2(0, -12.75)
+shape = SubResource("RectangleShape2D_fqdtv")
+debug_color = Color(1, 0, 0, 0.419608)
+script = ExtResource("21_jl70t")
+offset = Vector2(0, 10.5)
+link = NodePath("../../CrouchCollision")
 
 [node name="SmallShape" type="CollisionShape2D" parent="BlockCollision" node_paths=PackedStringArray("link") groups=["SmallCollisions"]]
 visible = false

--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -436,10 +436,18 @@ func handle_directions() -> void:
 var use_big_collision := false
 
 func handle_power_up_states(delta) -> void:
+	var small_crouch := power_state.hitbox_size == "Small" and crouching
+	var big_crouch := power_state.hitbox_size == "Big" and crouching
+	for i in get_tree().get_nodes_in_group("SmallCollisions"):
+		if i.owner == self:
+			if i.name.begins_with("Crouch"):
+				i.set_deferred("disabled", power_state.hitbox_size == "Small" and !crouching)
+			else:
+				i.set_deferred("disabled", small_crouch or power_state.hitbox_size == "Big" and !crouching)
 	for i in get_tree().get_nodes_in_group("BigCollisions"):
 		if i.owner == self:
-			i.set_deferred("disabled", power_state.hitbox_size == "Small" or crouching)
-	$Checkpoint.position.y = -24 if power_state.hitbox_size == "Small" or crouching else -40
+			i.set_deferred("disabled", power_state.hitbox_size == "Small" or big_crouch)
+	$Checkpoint.position.y = -20 if small_crouch else -24 if power_state.hitbox_size == "Small" or big_crouch else -40
 	power_state.update(delta)
 
 func handle_wing_flight(delta: float) -> void:


### PR DESCRIPTION
Adds a quick change to parallel SMM2. I noticed when trying to duck under a Rocky Wrench's wrench while small, I still got hit. So I added an extra hitbox for when you crouch and are small. It was actually incredibly hard to test if this was accurate in SMM2 since the enemy had Stormtrooper aim. But when it throws a wrench directly at your face and you duck, you can dodge it.

https://github.com/user-attachments/assets/74fa0bf8-0867-4cd1-85f1-3cb05f77bcb0

https://github.com/user-attachments/assets/cb24f508-8a59-469d-8062-5cb55706beb3

