### PR TITLE
Updated Red Coins in Coin Blocks

### DIFF
--- a/Scripts/Classes/Blocks/BrickBlock.gd
+++ b/Scripts/Classes/Blocks/BrickBlock.gd
@@ -1,7 +1,7 @@
 class_name BrickBlock
 extends Block
 
-var ticking_down := false
+var times_hit := 0
 
 func _ready() -> void:
 	if item_amount == 10 and item.resource_path == "res://Scenes/Prefabs/Entities/Items/SpinningCoin.tscn" and is_instance_valid(Global.level_editor) == false:
@@ -11,6 +11,7 @@ func check_brick_empty() -> void:
 	$PSwitcher.enabled = item == null
 
 func on_block_hit(player: Player) -> void:
+	times_hit += 1
 	if player.power_state.hitbox_size == "Big":
 		if item == null:
 			await get_tree().physics_frame
@@ -30,4 +31,6 @@ func on_shell_block_hit(_shell: Shell) -> void:
 		dispense_item()
 
 func set_coin_count() -> void:
-	item_amount = 2
+	if times_hit >= 9 and Global.current_game_mode == Global.GameMode.CHALLENGE:
+		item = load("res://Scenes/Prefabs/Entities/Items/SpinningRedCoin.tscn")
+	item_amount = 1


### PR DESCRIPTION
This PR adjusts the conditions of the Red Coin when they're contained in a Coin Brick Block. NOTE: In SMB Deluxe, the Red Coin appears exactly on the 10th hit of a Coin Brick Block, but I decided to have it appear after you hit the block 10 times or over to be looser and to rack up more score.
(Ignore the coin sparkle, I repurposed the video I took to showcase the Red Coin since this is split off from an existing PR).

https://github.com/user-attachments/assets/abadc31d-f308-4b98-97d7-4ed46a2e5dc5

- When hitting a Coin Brick Block after some time, it produces 1 coin after hitting again instead of 2
- The Red Coin will only pop out of Coin Brick Blocks after being hit at least 9 times prior to the timeout. On the 10th hit or greater, the coin will pop out.