### PR TITLE
Added Debug DLLs to Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /android/
 Exports/
 Assets/LevelGuides
+addons/discord-rpc-gd/bin/windows/~discord_game_sdk_binding_debug.dll
+godotgif/bin/~godotgif.windows.template_debug.x86_64.dll


### PR DESCRIPTION
This is honestly getting on my nerves.
Includes whatever this debug DLL thing is into the `.gitignore` file. Nothing much, but for me personally, it's been really hard to work with these things getting in the way. Especially when they only appear when the Godot Project is opened and disappear when it's closed.