### PR TITLE
Fixed initial window size from being tiny

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -48,6 +48,8 @@ gdscript/warnings/narrowing_conversion=0
 
 window/size/viewport_width=256
 window/size/viewport_height=240
+window/size/window_width_override=1024
+window/size/window_height_override=960
 window/stretch/mode="viewport"
 
 [dotnet]


### PR DESCRIPTION
In the nightly builds the sizes of the initial windows are incredibly tiny leading to complaints from various people, this is due to two properties regarding the initial resolution being removed in commit https://github.com/JHDev2006/Super-Mario-Bros.-Remastered-Public/commit/922c29cc8175b4773806d982661a5340c040d049

These specific lines were removed from `project.godot`
```
window/size/window_width_override=1024
window/size/window_height_override=960
```