### PR TITLE
Modified the issue template to contain a version number

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+**Version used**
+The full version string found at the bottom left of the main menu
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
Added a field for the version number in the template.
It tells players to put the **entire** version string and it tells them that the version number is at the bottom left of the main menu.
This will help both with stable builds and the nightly builds which as of today use the githash they were built with as a version number instead of the old date system which wasn't accurate.