### PR TITLE
Custom Characters Appearing in Non-Portable

### DIFF
--- a/Scripts/UI/CharacterSelect.gd
+++ b/Scripts/UI/CharacterSelect.gd
@@ -41,8 +41,7 @@ func get_custom_characters() -> void:
 		idx += 1
 	print(Player.CHARACTER_NAMES)
 	
-	var base_path = Global.config_path
-	var char_dir = base_path.path_join("custom_characters")
+	var char_dir = Global.config_path.path_join("custom_characters")
 		
 	for i in DirAccess.get_directories_at(char_dir):
 		var char_path = char_dir.path_join(i)

--- a/Scripts/UI/CharacterSelect.gd
+++ b/Scripts/UI/CharacterSelect.gd
@@ -41,7 +41,7 @@ func get_custom_characters() -> void:
 		idx += 1
 	print(Player.CHARACTER_NAMES)
 	
-	var base_path = Global.config_path.rstrip("/")
+	var base_path = Global.config_path
 	var char_dir = base_path.path_join("custom_characters")
 		
 	for i in DirAccess.get_directories_at(char_dir):


### PR DESCRIPTION
A quick bugfix that should fix an issue with custom characters only appearing in a portable build. I realized this was an issue because I have to use custom characters for debugging purposes, and none of them appeared in the Godot Project Debug.