### PR TITLE
Add export option to disable gamepad input

### DIFF
--- a/Scenes/Prefabs/UI/SettingsMenu.tscn
+++ b/Scenes/Prefabs/UI/SettingsMenu.tscn
@@ -46,6 +46,8 @@ var actions := [\"jump\", \"run\", \"action\", \"move_left\", \"move_right\", \"
 func _ready() -> void:
 	get_input_nodes()
 	load_inputs()
+	if ProjectSettings.get_setting(\"application/disable_gamepad\", false):
+		disable_gamepad()
 
 func get_input_nodes() -> void:
 	input_nodes.clear()
@@ -68,6 +70,8 @@ func load_inputs() -> void:
 			var event: InputEvent = null
 			if value == null:
 				continue
+			if type == 1 and ProjectSettings.get_setting(\"application/disable_gamepad\", false):
+				continue
 			if type == 0:
 				event = InputEventKey.new()
 				event.keycode = OS.find_keycode_from_string(value)
@@ -87,11 +91,18 @@ func update_starting_values() -> void:
  
 func save_inputs() -> void:
 	for i in actions:
-		var event = null
-		if i.contains(\"ui\") or i == \"pause\":
-			event = InputMap.action_get_events(i)[type]
-		else:
-			event = InputMap.action_get_events(i + \"_0\")[type]
+		var events = InputMap.action_get_events(i)
+		var event: InputEvent = null
+		for e in events:
+			if type == 0 and e is InputEventKey:
+				event = e
+				break
+			elif type == 1 and (e is InputEventJoypadButton or e is InputEventJoypadMotion):
+				event = e
+				break
+		if event == null:
+			continue
+
 		var rep
 		if event is InputEventKey:
 			rep = OS.get_keycode_string(event.keycode)
@@ -100,8 +111,25 @@ func save_inputs() -> void:
 		elif event is InputEventJoypadMotion:
 			rep = str(event.axis) + \",\" + str(event.axis_value)
 		else:
-			pass
+			continue
+
 		Settings.file[[\"keyboard\", \"controller\"][type]][i] = rep
+
+func disable_gamepad() -> void:
+		var actions = InputMap.get_actions()
+		for action in actions:
+			if InputMap.has_action(action):
+				var events = InputMap.action_get_events(action)
+				if events.is_empty():
+					continue
+				var events_to_remove = []
+				for event in events:
+					if event is InputEventJoypadButton:
+						events_to_remove.append(event)
+					elif event is InputEventJoypadMotion:
+						events_to_remove.append(event)
+				for event in events_to_remove:
+					InputMap.action_erase_event(action, event)
 "
 
 [sub_resource type="StyleBoxLine" id="StyleBoxLine_k6yev"]

--- a/Scripts/UI/SelectableInputOptionNode.gd
+++ b/Scripts/UI/SelectableInputOptionNode.gd
@@ -93,7 +93,15 @@ func map_event_to_action(event) -> void:
 		if action.contains("ui_") == false and action != "pause":
 			action = action_name + "_" + str(player_idx)
 		var events = InputMap.action_get_events(action).duplicate()
-		events[type] = event
+		var replaced = false
+		for i in range(events.size()):
+			if events[i].get_class() == event.get_class():
+				events[i] = event
+				replaced = true
+				break
+		if not replaced:
+			events.append(event)
+		
 		InputMap.action_erase_events(action)
 		for i in events:
 			InputMap.action_add_event(action, i)

--- a/Scripts/UI/SettingsMenu.gd
+++ b/Scripts/UI/SettingsMenu.gd
@@ -16,7 +16,15 @@ var active = false
 
 signal opened
 
+func _ready() -> void:
+	if ProjectSettings.get_setting("application/disable_gamepad", false):
+		disabled_containers.append($PanelContainer/MarginContainer/VBoxContainer/Controller)
+
 func _process(_delta: float) -> void:
+	while disabled_containers.has(current_container):
+		category_index = wrap(category_index + 1, 0, containers.size())
+		current_container = containers[category_index]
+	
 	category_select_active = current_container.selected_index == -1 and active
 	%Category.text = tr(current_container.category_name)
 	%Icon.region_rect.position.x = category_index * 24
@@ -38,19 +46,21 @@ func _process(_delta: float) -> void:
 func handle_inputs() -> void:
 	var direction := 0
 	if Input.is_action_just_pressed("ui_left"):
-		category_index -= 1
 		direction = -1
 		if Settings.file.audio.extra_sfx == 1:
 			AudioManager.play_global_sfx("menu_move")
-	if Input.is_action_just_pressed("ui_right"):
-		category_index += 1
-		direction += 1
+	elif Input.is_action_just_pressed("ui_right"):
+		direction = 1
 		if Settings.file.audio.extra_sfx == 1:
 			AudioManager.play_global_sfx("menu_move")
-	category_index = wrap(category_index, 0, containers.size())
-	current_container = containers[category_index]
-	if disabled_containers.has(current_container):
+	
+	if direction != 0:
 		category_index = wrap(category_index + direction, 0, containers.size())
+		current_container = containers[category_index]
+
+		while disabled_containers.has(current_container):
+			category_index = wrap(category_index + direction, 0, containers.size())
+			current_container = containers[category_index]
 
 func open_pack_config_menu(pack: ResourcePackContainer) -> void:
 	$ResourcePackConfigMenu.config_json = pack.config

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ boot_splash/fullsize=false
 boot_splash/use_filter=false
 config/icon="res://icon.png"
 use_discord=true
+disable_gamepad=false
 
 [autoload]
 


### PR DESCRIPTION
This pull request adds an export option to disable gamepad input. The justification is that since this project seemingly doesn't use sdlgamecontrollerdb, various third party controllers may have confusing inputs. For example, on a retro handheld device, Button 0 may be L1 instead of the expected A or B.

In such cases, it is preferable to disable the gamepad interpretation on the engine side and allow a third party tool to translate keyboard inputs to desired button counterparts.