### PR TITLE
Proposed change: Make Challenge Hunt HUD not include red coins / eggs found on previous runs when in a level

### DIFF
--- a/Scenes/Prefabs/UI/StoryPause.tscn
+++ b/Scenes/Prefabs/UI/StoryPause.tscn
@@ -17,7 +17,7 @@ func restart_level() -> void:
 	DiscoLevel.reset_values()
 	if Global.current_game_mode == Global.GameMode.CHALLENGE:
 		Global.score = 0
-		ChallengeModeHandler.current_run_red_coins_collected = ChallengeModeHandler.red_coins_collected[Global.world_num - 1][Global.level_num - 1]
+		ChallengeModeHandler.current_run_red_coins_collected = 0
 	Global.current_level.reload_level()
 	await Global.current_level.tree_exited
 	$\"..\".close()

--- a/Scripts/Classes/Entities/Items/RedCoin.gd
+++ b/Scripts/Classes/Entities/Items/RedCoin.gd
@@ -9,7 +9,7 @@ var can_spawn_particles := false
 @onready var COIN_SPARKLE = load("res://Scenes/Prefabs/Particles/RedCoinSparkle.tscn")
 
 func _ready() -> void:
-	if ChallengeModeHandler.is_coin_collected(id):
+	if ChallengeModeHandler.is_coin_collected(id) or ChallengeModeHandler.is_coin_permanently_collected(id):
 		already_collected = true
 		$Sprite.play("Collected")
 		set_visibility_layer_bit(0, false)

--- a/Scripts/Classes/Entities/Items/SpinningRedCoin.gd
+++ b/Scripts/Classes/Entities/Items/SpinningRedCoin.gd
@@ -12,7 +12,7 @@ var can_spawn_particles := false
 @onready var COIN_SPARKLE = load("res://Scenes/Prefabs/Particles/RedCoinSparkle.tscn")
 
 func _ready() -> void:
-	already_collected = ChallengeModeHandler.is_coin_collected(id)
+	already_collected = ChallengeModeHandler.is_coin_collected(id) or ChallengeModeHandler.is_coin_permanently_collected(id)
 	if already_collected == false:
 		ChallengeModeHandler.red_coins += 1
 		AudioManager.play_sfx(collection_sounds[ChallengeModeHandler.red_coins - 1], global_position)

--- a/Scripts/Classes/Singletons/ChallengeModeHandler.gd
+++ b/Scripts/Classes/Singletons/ChallengeModeHandler.gd
@@ -81,6 +81,10 @@ static func set_value(coin_id := CoinValues.R_COIN_1, value := false) -> void:
 
 static func is_coin_collected(coin_id: CoinValues = CoinValues.R_COIN_1, num := current_run_red_coins_collected) -> bool:
 	return num & (1 << coin_id) != 0
+	
+static func is_coin_permanently_collected(coin_id: CoinValues = CoinValues.R_COIN_1) -> bool:
+	var permanently_collected = int(red_coins_collected[Global.world_num - 1][Global.level_num - 1])
+	return permanently_collected & (1 << coin_id) != 0
 
 func check_for_achievement() -> void:
 	for x in red_coins_collected:

--- a/Scripts/Parts/GameOver.gd
+++ b/Scripts/Parts/GameOver.gd
@@ -50,7 +50,7 @@ func quit_to_menu() -> void:
 
 func reset_values() -> void:
 	if Global.world_num <= 8:
-		ChallengeModeHandler.current_run_red_coins_collected = ChallengeModeHandler.red_coins_collected[Global.world_num - 1][Global.level_num - 1]
+		ChallengeModeHandler.current_run_red_coins_collected = 0
 	Global.lives = 3
 	Global.score = 0
 	Global.player_power_states = "0000"

--- a/Scripts/Parts/TitleScreen.gd
+++ b/Scripts/Parts/TitleScreen.gd
@@ -194,7 +194,7 @@ func challenge_hunt_start() -> void:
 
 
 	LevelTransition.level_to_transition_to = Level.get_scene_string(Global.world_num, Global.level_num)
-	ChallengeModeHandler.current_run_red_coins_collected = ChallengeModeHandler.red_coins_collected[Global.world_num - 1][Global.level_num -1]
+	ChallengeModeHandler.current_run_red_coins_collected = 0
 	Global.transition_to_scene("res://Scenes/Levels/LevelTransition.tscn")
 
 func world_9_selected() -> void:


### PR DESCRIPTION
This implements a change I proposed that makes the Challenge Mode HUD not include coins / Yoshi Eggs collected on previous runs by default.  This could be beneficial to the player by allowing them to still find Yoshi Eggs by radar, as well as to remember which red coin is which upon picking them up.

The HUD before selecting a level on the title screen, and the icons shown on level select should not be affected by this change.

Red coins will still show up as outlined if collected on a previous run (I introduced a new function for checking if coins were permanently collected, because I thought it would be cleaner than calling the is_coin_collected function again on the global scores, but I'm happy to rework that part of the change):
<img width="512" height="480" alt="image" src="https://github.com/user-attachments/assets/9ea5850f-4a9a-48b5-92d4-48c9ff57abea" />