### PR TITLE
Force LF line endings in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf


### PR DESCRIPTION
Changes .gitattributes to [the one Godot normally creates when you enable version control for a project](https://github.com/godotengine/godot/blob/c834443ef1fa3516e30124d8afaf448353d31010/editor/version_control/editor_vcs_interface.cpp#L376-L377), which adds `eol=lf`. This should fix the extreme amount of line-ending related diffs created when developing on Windows without disabling `core.autocrlf` in the Git config.