### PR TITLE
Ability to change level themes with resource packs + Room variations

### DIFF
--- a/Assets/themes.json
+++ b/Assets/themes.json
@@ -1,0 +1,3 @@
+{
+	"properties": {"change_theme": false}
+}

--- a/Scenes/Prefabs/Global.tscn
+++ b/Scenes/Prefabs/Global.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=56 format=3 uid="uid://c3h2iqkvitqd2"]
+[gd_scene load_steps=58 format=3 uid="uid://c3h2iqkvitqd2"]
 
 [ext_resource type="PackedScene" uid="uid://bod0jkf7jc5pm" path="res://Scenes/Prefabs/GameHud.tscn" id="1_ctvpw"]
 [ext_resource type="Script" uid="uid://bbxqn16ekbpcl" path="res://Scripts/Classes/Singletons/Global.gd" id="1_t23sr"]
@@ -23,6 +23,8 @@
 [ext_resource type="Script" uid="uid://cbal8ms2oe1ik" path="res://Scripts/Classes/Components/ResourceSetterNew.gd" id="19_okfpr"]
 [ext_resource type="Texture2D" uid="uid://bhgjvnslkt143" path="res://Assets/Sprites/UI/PanelSelected.png" id="19_xspbb"]
 [ext_resource type="JSON" path="res://Assets/Sprites/UI/Cursor.json" id="20_3l3ph"]
+[ext_resource type="Script" uid="uid://uwwce2eoloan" path="res://Scripts/Parts/ThemeSetter.gd" id="24_m6bur"]
+[ext_resource type="JSON" path="res://Assets/themes.json" id="25_mpjtu"]
 
 [sub_resource type="Animation" id="Animation_6jmk5"]
 resource_name = "FadeIn"
@@ -430,6 +432,15 @@ metadata/_custom_type_script = "uid://ctsjagoa5t33f"
 script = ExtResource("19_l7dvb")
 labels = [NodePath("../CanvasLayer/VBoxContainer/ErrorMessage"), NodePath("../CanvasLayer/VBoxContainer/Comment"), NodePath("../CanvasLayer/VBoxContainer/Warning")]
 metadata/_custom_type_script = "uid://dt2p68xl462v2"
+
+[node name="ThemeSetter" type="Node" parent="." node_paths=PackedStringArray("node_to_affect", "property_node")]
+script = ExtResource("24_m6bur")
+node_to_affect = NodePath(".")
+property_node = NodePath(".")
+property_name = "theme_data"
+mode = 3
+resource_json = ExtResource("25_mpjtu")
+metadata/_custom_type_script = "uid://uwwce2eoloan"
 
 [connection signal="finished" from="ScoreTally" to="." method="on_score_sfx_finished"]
 [connection signal="finished" from="ScoreTallyEnd" to="." method="on_score_sfx_finished"]

--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -236,6 +236,8 @@ func get_variation_json(json := {}) -> Dictionary:
 			json = get_variation_json(json[world])
 	
 	var level_string = "Level" + str(Global.level_num)
+	if force_properties.has("Level"):
+		level_string = "Level" + str(force_properties.Level)
 	if json.has(level_string) == false:
 		level_string = "Level1"
 	if json.has(level_string):

--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -244,6 +244,30 @@ func get_variation_json(json := {}) -> Dictionary:
 		else:
 			json = get_variation_json(json[level_string])
 	
+	var room = "MainRoom"
+	if force_properties.has("Room"):
+		room = force_properties.Room
+	elif Global.current_level != null:
+		if Global.current_level is CoinHeaven:
+			room = "CoinHeaven"
+		else:
+			for i in Global.current_level.get_children():
+				if i is ExtraBGM:
+					if i.extra_track.resource_path == "res://Assets/Audio/BGM/Bonus.json":
+						room = "BonusRoom"
+						break
+	elif get_tree().current_scene is PipeCutscene:
+		room = "PipeCutscene"
+	elif get_tree().current_scene is TitleScreen:
+		room = "TitleScreen"
+	if json.has(room) == false:
+		room = "MainRoom"
+	if json.has(room):
+		if json.get(room).has("link"):
+			json = get_variation_json(json[json.get(room).get("link")])
+		else:
+			json = get_variation_json(json[room])
+	
 	var game_mode = "GameMode:" + Global.game_mode_strings[Global.current_game_mode]
 	if json.has(game_mode) == false:
 		game_mode = "GameMode:" + Global.game_mode_strings[0]

--- a/Scripts/Classes/Singletons/AudioManager.gd
+++ b/Scripts/Classes/Singletons/AudioManager.gd
@@ -216,12 +216,12 @@ func handle_music() -> void:
 	
 	if is_instance_valid(Global.current_level):
 		var music: JSON = Global.current_level.music
-		if ThemeSetter.music != null and music == ThemeSetter.music_to_replace:
-			music = ThemeSetter.music
 		if music == null or current_music_override != MUSIC_OVERRIDES.NONE:
 			music_player.stop()
 			handle_music_override()
 			return
+		elif ThemeSetter.music != null and ThemeSetter.music_to_replace == music.resource_path:
+			music = ThemeSetter.music
 		music_player.stream_paused = false
 		if current_level_theme != music.resource_path and music != null:
 			var stream = create_stream_from_json(music.resource_path)

--- a/Scripts/Classes/Singletons/AudioManager.gd
+++ b/Scripts/Classes/Singletons/AudioManager.gd
@@ -215,15 +215,18 @@ func handle_music() -> void:
 	AudioServer.set_bus_effect_enabled(1, 0, Global.game_paused and Settings.file.audio.pause_bgm == 1)
 	
 	if is_instance_valid(Global.current_level):
-		if Global.current_level.music == null or current_music_override != MUSIC_OVERRIDES.NONE:
+		var music: JSON = Global.current_level.music
+		if ThemeSetter.music != null and music == ThemeSetter.music_to_replace:
+			music = ThemeSetter.music
+		if music == null or current_music_override != MUSIC_OVERRIDES.NONE:
 			music_player.stop()
 			handle_music_override()
 			return
 		music_player.stream_paused = false
-		if current_level_theme != Global.current_level.music.resource_path and Global.current_level.music != null:
-			var stream = create_stream_from_json(Global.current_level.music.resource_path)
+		if current_level_theme != music.resource_path and music != null:
+			var stream = create_stream_from_json(music.resource_path)
 			music_player.stream = stream
-			current_level_theme = Global.current_level.music.resource_path
+			current_level_theme = music.resource_path
 		if music_player.is_playing() == false and current_music_override == MUSIC_OVERRIDES.NONE:
 			music_player.stop()
 			current_music_override = MUSIC_OVERRIDES.NONE

--- a/Scripts/Parts/ThemeSetter.gd
+++ b/Scripts/Parts/ThemeSetter.gd
@@ -30,7 +30,7 @@ const MUSIC_TRACKS := {
 var updating := false
 
 static var music: JSON
-static var music_to_replace: JSON
+static var music_to_replace := ""
 
 func get_resource(json_file: JSON) -> Resource:
 	if cache.has(json_file.resource_path) and use_cache and force_properties.is_empty():
@@ -88,14 +88,14 @@ func set_theme(json := {}) -> void:
 			Global.level_theme = json.theme
 			if sync_music:
 				music = load(MUSIC_TRACKS[json.theme])
-				music_to_replace = load(MUSIC_TRACKS[get_default_theme()])
+				music_to_replace = MUSIC_TRACKS[get_default_theme()]
 			else:
 				music = null
-				music_to_replace = null
+				music_to_replace = ""
 		else:
 			Global.level_theme = get_default_theme()
 			music = null
-			music_to_replace = null
+			music_to_replace = ""
 		if json.has("time") and json.time is String and ["Day", "Night"].has(json.time):
 			Global.theme_time = json.time
 		else:
@@ -104,7 +104,7 @@ func set_theme(json := {}) -> void:
 		Global.level_theme = get_default_theme()
 		Global.theme_time = get_default_time()
 		music = null
-		music_to_replace = null
+		music_to_replace = ""
 	updating = false
 
 func get_level() -> Level:

--- a/Scripts/Parts/ThemeSetter.gd
+++ b/Scripts/Parts/ThemeSetter.gd
@@ -1,0 +1,137 @@
+class_name ThemeSetter
+extends ResourceSetterNew
+
+const MUSIC_TRACKS := {
+	"Overworld": "res://Assets/Audio/BGM/Overworld.json",
+	"Underground": "res://Assets/Audio/BGM/Underground.json",
+	"Desert": "res://Assets/Audio/BGM/Desert.json",
+	"Snow": "res://Assets/Audio/BGM/Snow.json",
+	"Jungle": "res://Assets/Audio/BGM/Jungle.json",
+	"Beach": "res://Assets/Audio/BGM/Beach.json",
+	"Garden": "res://Assets/Audio/BGM/Garden.json",
+	"Mountain": "res://Assets/Audio/BGM/Mountain.json",
+	"Skyland": "res://Assets/Audio/BGM/Sky.json",
+	"Autumn": "res://Assets/Audio/BGM/Autumn.json",
+	"Pipeland": "res://Assets/Audio/BGM/Pipeland.json",
+	"Space": "res://Assets/Audio/BGM/Space.json",
+	"Underwater": "res://Assets/Audio/BGM/Underwater.json",
+	"Volcano": "res://Assets/Audio/BGM/Volcano.json",
+	"GhostHouse": "res://Assets/Audio/BGM/GhostHouse.json",
+	"Castle": "res://Assets/Audio/BGM/Castle.json",
+	"CastleWater": "res://Assets/Audio/BGM/Underwater.json",
+	"Airship": "res://Assets/Audio/BGM/Airship.json",
+	"Bonus": "res://Assets/Audio/BGM/Bonus.json"
+}
+
+@export var theme_data: JSON
+@export var change_theme := false
+@export var sync_music := true
+
+var updating := false
+
+static var music: JSON
+static var music_to_replace: JSON
+
+func get_resource(json_file: JSON) -> Resource:
+	if cache.has(json_file.resource_path) and use_cache and force_properties.is_empty():
+		if property_cache.has(json_file.resource_path):
+			apply_properties(property_cache[json_file.resource_path])
+		return cache[json_file.resource_path]
+	
+	var resource: Resource = null
+	var resource_path = json_file.resource_path
+	config_to_use = {}
+	current_resource_pack = ""
+	for i in Settings.file.visuals.resource_packs:
+		var new_path = get_resource_pack_path(resource_path, i)
+		if resource_path != new_path or current_resource_pack == "":
+			current_resource_pack = i
+		resource_path = new_path
+	
+	var source_json = JSON.parse_string(FileAccess.open(resource_path, FileAccess.READ).get_as_text())
+	if source_json == null:
+		Global.log_error("Error parsing " + resource_path + "!")
+		return
+	resource = load(resource_path)
+	var json = source_json.duplicate()
+	if json.has("variations"):
+		json = get_variation_json(json.variations)
+	if json.has("properties"):
+		apply_properties(json.get("properties"))
+		if use_cache:
+			property_cache[json_file.resource_path] = json.properties.duplicate()
+	elif source_json.has("properties"):
+		apply_properties(source_json.get("properties"))
+		if use_cache:
+			property_cache[json_file.resource_path] = source_json.properties.duplicate()
+	if cache.has(json_file.resource_path) == false and use_cache and not is_random:
+		cache[json_file.resource_path] = resource
+	return resource
+
+func update_resource() -> void:
+	if is_inside_tree() == false or is_queued_for_deletion() or resource_json == null or node_to_affect == null or updating:
+		return
+	super()
+	force_properties = {
+		"Theme": get_default_theme(),
+		"Time": get_default_time()
+	}
+	if theme_data != null and theme_data.data.has("variations"):
+		set_theme(get_variation_json(theme_data.data.variations))
+	else:
+		set_theme()
+
+func set_theme(json := {}) -> void:
+	updating = true
+	if change_theme:
+		if json.has("theme") and json.theme is String and Level.THEME_IDXS.has(json.theme):
+			Global.level_theme = json.theme
+			if sync_music:
+				music = load(MUSIC_TRACKS[json.theme])
+				music_to_replace = load(MUSIC_TRACKS[get_default_theme()])
+			else:
+				music = null
+				music_to_replace = null
+		else:
+			Global.level_theme = get_default_theme()
+			music = null
+			music_to_replace = null
+		if json.has("time") and json.time is String and ["Day", "Night"].has(json.time):
+			Global.theme_time = json.time
+		else:
+			Global.theme_time = get_default_time()
+	else:
+		Global.level_theme = get_default_theme()
+		Global.theme_time = get_default_time()
+		music = null
+		music_to_replace = null
+	updating = false
+
+func get_level() -> Level:
+	if Global.current_level != null:
+		return Global.current_level
+	var scene := get_tree().current_scene
+	if scene is Level:
+		return scene
+	return null
+
+func get_default_theme() -> String:
+	var level := get_level()
+	if level != null:
+		if level.auto_set_theme:
+			return Level.WORLD_THEMES[Global.current_campaign][Global.world_num]
+		else:
+			return level.theme
+	return "Overworld"
+
+func get_default_time() -> String:
+	var level := get_level()
+	if level != null:
+		if level.auto_set_theme:
+			if range(4, 9).has(Global.world_num) or Global.current_campaign == "SMBANN":
+				return "Night"
+			else:
+				return "Day"
+		else:
+			return level.theme_time
+	return "Day"

--- a/Scripts/Parts/ThemeSetter.gd
+++ b/Scripts/Parts/ThemeSetter.gd
@@ -76,6 +76,11 @@ func update_resource() -> void:
 		"Theme": get_default_theme(),
 		"Time": get_default_time()
 	}
+	if Global.current_game_mode == Global.GameMode.BOO_RACE and Global.current_level != null:
+		force_properties.merge({
+			"World": Global.current_level.world_id,
+			"Level": Global.current_level.level_id
+		})
 	if theme_data != null and theme_data.data.has("variations"):
 		set_theme(get_variation_json(theme_data.data.variations))
 	else:

--- a/Scripts/Parts/ThemeSetter.gd.uid
+++ b/Scripts/Parts/ThemeSetter.gd.uid
@@ -1,0 +1,1 @@
+uid://uwwce2eoloan


### PR DESCRIPTION

I've created a ThemeSetter node set in the Global node that can change the themes of levels based on a themes.json file located in your resource packs. It follows all the same variations as other jsons, so you can change theme based off of world number, default theme, and so on.
I've also managed to add a new variation type: Rooms.
MainRoom, BonusRoom, CoinHeaven, PipeCutscene, and TitleScreen are all valid keys. (Hope that's self-explanatory)
I made sure to edit other scripts as little as possible, almost everything is handled in the ThemeSetter script.
I did have to make small edits to handle_music() in the AudioManager, but it should work exactly the same if no alternate themes are in use.
A single variation should be structured like this: {"theme": "Overworld", "time": "Day"}
There's also a couple of properties, such as:
"change_theme" - Setting this to false will keep/revert the theme back to its default. This easily allows for the themes of underground levels or custom levels to be kept intact without defining their themes manually.
"sync_music" - Changes the music to match the theme. This only works if the default music track matches the default theme.

https://github.com/user-attachments/assets/d8599597-bae4-4fcb-afb4-a71d43eb47a0

Extra notes:

- ThemeSetter handles theme and time variations slightly differently. Instead of going off of current theme, it uses the default for that level. Example: If you enable a pack that changes night levels to day levels and then a second one that changes night levels to space levels, the levels will still be counted as night even after being set to day.
- The theme system has NOT been reworked to depend on the themes.json. All levels maintain their default theme settings for ThemeSetter to make use of theme variations. While there is a default file in the Assets directory, it's only meant to serve as a reference to the themes.json directory since ThemeSetter inherits from ResourceSetterNew. Even if the ThemeSetter can change the theme, it does not change the variables to the level scenes directly, but rather the Global references. The ThemeSetter will simply do nothing or reset levels to their default themes if "change_theme" is set to false, which is the case in the base file.
- The BonusRoom variation key only works by searching through every child node of the current level to see if it has an ExtraBGM node with the bonus track. Not the most efficient method, but it shouldn't cause too much trouble. All other variations simply check the level's class.
- I noticed switching between campaigns on the title screen takes a bit longer as a result of the ThemeSetter, but hopefully that shouldn't be too much of a problem.