### PR TITLE
Miscellaneous Bugfixes From My Multiplayer Branch

### DIFF
--- a/Scripts/Classes/Components/ResourceSetter.gd
+++ b/Scripts/Classes/Components/ResourceSetter.gd
@@ -11,11 +11,9 @@ signal sprites_updated
 
 static var cache := {}
 
-func _enter_tree() -> void:
+func _ready() -> void:
 	Global.level_theme_changed.connect(update_sprites)
 	Global.level_time_changed.connect(update_sprites)
-
-func _ready() -> void:
 	update_sprites()
 
 func update_sprites() -> void:

--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -36,17 +36,18 @@ var update_on_spawn := true
 func _init() -> void:
 	set_process_mode(Node.PROCESS_MODE_ALWAYS)
 
+func _ready() -> void:
+	Global.level_time_changed.connect(update_resource)
+	Global.level_theme_changed.connect(update_resource)
+
 func _enter_tree() -> void:
 	safety_check()
 	if update_on_spawn:
 		update_resource()
-	Global.level_time_changed.connect(update_resource)
-	Global.level_theme_changed.connect(update_resource)
-	
 
 func safety_check() -> void:
-	if Settings.file.visuals.resource_packs.has("BaseAssets") == false:
-		Settings.file.visuals.resource_packs.append("BaseAssets")
+	if Settings.file.visuals.resource_packs.has(Global.ROM_PACK_NAME) == false:
+		Settings.file.visuals.resource_packs.insert(Global.ROM_PACK_NAME, 0)
 
 func update_resource() -> void:
 	randomize()

--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -425,7 +425,7 @@ func add_stomp_combo(award_score := true) -> void:
 				score_note_spawner.spawn_note(10000)
 			else:
 				Global.lives += 1
-				AudioManager.play_global_sfx("1_up")
+				AudioManager.play_sfx("1_up", global_position)
 				score_note_spawner.spawn_one_up_note()
 	else:
 		if award_score:
@@ -564,8 +564,6 @@ func die(pit := false) -> void:
 	visible = not pit
 	flight_meter = 0
 	dead.emit()
-	Global.p_switch_active = false
-	Global.p_switch_timer = 0
 	stop_all_timers()
 	Global.total_deaths += 1
 	sprite.process_mode = Node.PROCESS_MODE_ALWAYS
@@ -803,8 +801,6 @@ func jump() -> void:
 	velocity.y = calculate_jump_height() * gravity_vector.y
 	gravity = JUMP_GRAVITY
 	AudioManager.play_sfx("small_jump" if power_state.hitbox_size == "Small" else "big_jump", global_position)
-	has_jumped = true
-	await get_tree().physics_frame
 	has_jumped = true
 
 func calculate_jump_height() -> float: # Thanks wye love you xxx

--- a/Scripts/Classes/LevelClass.gd
+++ b/Scripts/Classes/LevelClass.gd
@@ -123,7 +123,8 @@ func update_theme() -> void:
 	Global.level_theme = theme
 	Global.theme_time = theme_time
 	TitleScreen.last_theme = theme
-	$LevelBG.update_visuals()
+	if get_node_or_null("LevelBG") != null:
+		$LevelBG.update_visuals()
 
 func update_next_level_info() -> void:
 	next_level = wrap(level_id + 1, 1, 5)

--- a/Scripts/Classes/Singletons/AudioManager.gd
+++ b/Scripts/Classes/Singletons/AudioManager.gd
@@ -5,6 +5,7 @@ const DEFAULT_SFX_LIBRARY := {
 	"big_jump": ("res://Assets/Audio/SFX/BigJump.wav"),
 	"coin": ("res://Assets/Audio/SFX/Coin.wav"),
 	"bump": ("res://Assets/Audio/SFX/Bump.wav"),
+	"skid": ("res://Assets/Audio/SFX/Skid.wav"),
 	"pipe": ("res://Assets/Audio/SFX/Pipe.wav"),
 	"damage": ("res://Assets/Audio/SFX/Damage.wav"),
 	"power_up": ("res://Assets/Audio/SFX/Powerup.wav"),

--- a/Scripts/Classes/Singletons/Global.gd
+++ b/Scripts/Classes/Singletons/Global.gd
@@ -327,6 +327,8 @@ func reset_values() -> void:
 	Level.in_vine_level = false
 	Level.vine_return_level = ""
 	Level.vine_warp_level = ""
+	p_switch_active = false
+	p_switch_timer = 0.0
 
 func clear_saved_values() -> void:
 	coins = 0

--- a/Scripts/Classes/Singletons/SettingsManager.gd
+++ b/Scripts/Classes/Singletons/SettingsManager.gd
@@ -12,9 +12,9 @@ var file := {
 		"frame_limit" : 0,
 	},
 	"audio": {
-		"master": 10.0,
-		"music": 10.0,
-		"sfx": 10.0,
+		"master": 10,
+		"music": 10,
+		"sfx": 10,
 		"athletic_bgm": 1,
 		"extra_bgm": 1,
 		"skid_sfx": 1,
@@ -24,8 +24,7 @@ var file := {
 	},
 	"game": {
 		"campaign": "SMB1",
-		"lang": "en",
-		"character": "0000"
+		"lang": "en"
 	},
 	"keyboard":
 	{

--- a/Scripts/Parts/PipeCutscene.gd
+++ b/Scripts/Parts/PipeCutscene.gd
@@ -27,4 +27,4 @@ func go_to_level() -> void:
 	Global.transition_to_scene(LevelTransition.level_to_transition_to)
 
 func play_pipe_sfx() -> void:
-	AudioManager.play_global_sfx("pipe")
+	AudioManager.play_sfx("pipe", $Player1.global_position)

--- a/Scripts/UI/StoryPause.gd
+++ b/Scripts/UI/StoryPause.gd
@@ -48,7 +48,7 @@ func open() -> void:
 		AudioManager.play_global_sfx("pause")
 		get_tree().paused = true
 	show()
-	await get_tree().physics_frame
+	await get_tree().create_timer(0.1).timeout
 	active = true
 
 func close() -> void:
@@ -56,7 +56,6 @@ func close() -> void:
 	selected_index = 0
 	hide()
 	closed.emit()
-	for i in 2:
-		await get_tree().physics_frame
+	await get_tree().create_timer(0.1).timeout
 	Global.game_paused = false
 	get_tree().paused = false


### PR DESCRIPTION
This is just a bunch of bugfixes I did while I was working on the Multiplayer Support PR. I know I should've kept them separate, but then I'd also be dealing with said bugs. So this PR adds most of the bugfixes I did while working on Multiplayer.

- De-globalized Pipe SFX from Pipe Cutscene (helps with lowering audio)
- De-globalized 1-up SFX for Players
- Removed an error log spam with the `ResourceSetter`s (involving connecting already connected signals)
- Made sure to insert "BaseAssets" folder into the FIRST slot in the Resource Packs array.
- Replaced `"BaseAssets"` for the above fix with `Godot.ROM_PACK_NAME`
- Removed unused `"character"` setting from `SettingsManager`
- Reset P-Switch timer when `Global.reset_values()` is called. Fixes bug when pressing a P-Switch and immediately restarting the level.
- Added Skid SFX to `AudioManager`
- Added slightly longer delay for when pausing with a controller (it can easily unpause before you press the button again)
- Null check if LevelBG is in the level or not (for added for test levels)