### PR TITLE
Room variation types

### DIFF
--- a/Scripts/Classes/CoinHeaven.gd
+++ b/Scripts/Classes/CoinHeaven.gd
@@ -13,3 +13,6 @@ func warp_back(player: Player) -> void:
 	await get_tree().create_timer(1, false).timeout
 	PipeArea.exiting_pipe_id = -1
 	Global.transition_to_scene(Level.vine_return_level)
+
+func get_room_type() -> Global.Room:
+	return Global.Room.COIN_HEAVEN

--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -18,7 +18,7 @@ static var property_cache := {}
 
 var current_json_path := ""
 
-static var state := [0, 0]
+static var state := [0, 0, 0]
 
 static var pack_configs := {}
 
@@ -53,7 +53,7 @@ func update_resource() -> void:
 	randomize()
 	if is_inside_tree() == false or is_queued_for_deletion() or resource_json == null or node_to_affect == null:
 		return
-	if state != [Global.level_theme, Global.theme_time]:
+	if state != [Global.level_theme, Global.theme_time, Global.current_room]:
 		cache.clear()
 		property_cache.clear()
 	if node_to_affect != null:
@@ -61,7 +61,7 @@ func update_resource() -> void:
 		node_to_affect.set(property_name, resource)
 		if node_to_affect is AnimatedSprite2D:
 			node_to_affect.play()
-	state = [Global.level_theme, Global.theme_time]
+	state = [Global.level_theme, Global.theme_time, Global.current_room]
 	updated.emit()
 
 func get_resource(json_file: JSON) -> Resource:
@@ -244,6 +244,15 @@ func get_variation_json(json := {}) -> Dictionary:
 			json = get_variation_json(json[json.get(level_string).get("link")])
 		else:
 			json = get_variation_json(json[level_string])
+	
+	var room = Global.room_strings[Global.current_room]
+	if json.has(room) == false:
+		room = Global.room_strings[0]
+	if json.has(room):
+		if json.get(room).has("link"):
+			json = get_variation_json(json[json.get(room).get("link")])
+		else:
+			json = get_variation_json(json[room])
 	
 	var game_mode = "GameMode:" + Global.game_mode_strings[Global.current_game_mode]
 	if json.has(game_mode) == false:

--- a/Scripts/Classes/LevelClass.gd
+++ b/Scripts/Classes/LevelClass.gd
@@ -51,6 +51,13 @@ const SMBS_THEMES := {
 	8: "Overworld"
 }
 
+const BONUS_ROOMS := {
+	"SMB1": ["1-1a", "1-2a", "2-1a", "3-1a", "4-1a", "4-2a", "5-1a", "6-2a", "6-2c", "7-1a", "8-1a", "8-2a"],
+	"SMBLL": ["1-1a", "2-1a", "2-2a", "3-1b", "4-2a", "5-1a", "5-3a", "7-1c", "7-2a", "10-1a", "12-1a", "13-1a", "13-2a", "13-4b"],
+	"SMBS": ["1-1a", "1-2a", "6-2a", "6-2b", "6-2c", "6-2d", "6-3a", "7-1a", "7-3a"],
+	"SMBANN": ["1-1a", "1-2a", "2-1a", "3-1a", "4-1a", "4-2a", "5-1a", "6-2a", "6-2c", "7-1a", "8-1a", "8-2a"]
+}
+
 @export var auto_set_theme := false
 
 @export var time_limit := 400
@@ -119,6 +126,7 @@ func update_theme() -> void:
 		if Global.current_campaign == "SMBANN":
 			theme_time = "Night"
 		ResourceSetterNew.cache.clear()
+	Global.current_room = get_room_type()
 	Global.current_campaign = campaign
 	Global.level_theme = theme
 	Global.theme_time = theme_time
@@ -165,3 +173,8 @@ func reload_level() -> void:
 		Global.transition_to_scene(LevelTransition.level_to_transition_to)
 	else:
 		Global.transition_to_scene("res://Scenes/Levels/LevelTransition.tscn")
+
+func get_room_type() -> Global.Room:
+	if BONUS_ROOMS[campaign].has(scene_file_path.get_file().get_basename()):
+		return Global.Room.BONUS_ROOM
+	return Global.Room.MAIN_ROOM

--- a/Scripts/Classes/Singletons/Global.gd
+++ b/Scripts/Classes/Singletons/Global.gd
@@ -89,6 +89,12 @@ var world_num := 1
 var level_num := 1
 var disco_mode := false
 
+enum Room{MAIN_ROOM, BONUS_ROOM, COIN_HEAVEN, PIPE_CUTSCENE, TITLE_SCREEN}
+
+const room_strings := ["MainRoom", "BonusRoom", "CoinHeaven", "PipeCutscene", "TitleScreen"]
+
+var current_room: Room = Room.MAIN_ROOM
+
 signal transition_finished
 var transitioning_scene := false
 var awaiting_transition := false

--- a/Scripts/Parts/PipeCutscene.gd
+++ b/Scripts/Parts/PipeCutscene.gd
@@ -10,6 +10,7 @@ func _enter_tree() -> void:
 		theme_time = "Night"
 	else:
 		theme_time = "Day"
+	Global.current_room = get_room_type()
 	Global.level_theme = theme
 	Global.theme_time = theme_time
 
@@ -28,3 +29,6 @@ func go_to_level() -> void:
 
 func play_pipe_sfx() -> void:
 	AudioManager.play_sfx("pipe", $Player1.global_position)
+
+func get_room_type() -> Global.Room:
+	return Global.Room.PIPE_CUTSCENE

--- a/Scripts/Parts/TitleScreen.gd
+++ b/Scripts/Parts/TitleScreen.gd
@@ -263,3 +263,6 @@ func check_for_unlocked_achievements() -> void:
 		has_achievements_to_unlock = true
 		%AchievementUnlock.show_popup(new_achievements)
 	AchievementMenu.unlocked_achievements = Global.achievements
+
+func get_room_type() -> Global.Room:
+	return Global.Room.TITLE_SCREEN


### PR DESCRIPTION
Adds new variations for room types.
Valid keys include: MainRoom, BonusRoom, CoinHeaven, PipeCutscene, and TitleScreen. (Defaults to MainRoom)

If you've seen my Theme Setter PR, it doesn't work the same way anymore. It works closer to how level themes and game modes are retrieved by each ResourceSetterNew. The way bonus rooms are detected should be more efficient now.