### PR TITLE
New transition screen + no lives in modern hud for challenge mode

### DIFF
--- a/Scenes/Levels/LevelTransition.tscn
+++ b/Scenes/Levels/LevelTransition.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=7 format=3 uid="uid://ckpuxdilk5u0"]
+[gd_scene load_steps=9 format=3 uid="uid://ckpuxdilk5u0"]
 
 [ext_resource type="Script" uid="uid://vwe7y2scu8a1" path="res://Scripts/Parts/LevelTransition.gd" id="1_75ji3"]
 [ext_resource type="SpriteFrames" uid="uid://df4enjjl84mji" path="res://Resources/SpriteFrames/Player/Mario/Small.tres" id="3_y8ytj"]
+[ext_resource type="Texture2D" uid="uid://de6otencrflfo" path="res://Assets/Sprites/UI/RedCoins.png" id="5_ehrek"]
 [ext_resource type="Script" uid="uid://b08qfwj5jk6g1" path="res://Scripts/Parts/PlayerSprite.gd" id="5_jsg51"]
 [ext_resource type="Script" uid="uid://cbal8ms2oe1ik" path="res://Scripts/Classes/Components/ResourceSetterNew.gd" id="5_mcaat"]
+[ext_resource type="Script" uid="uid://364rywt44hy6" path="res://Scripts/Classes/UI/PackSprite.gd" id="6_abjth"]
 [ext_resource type="Script" uid="uid://co6tjg3w6qpd8" path="res://Scripts/Parts/LabelFontChanger.gd" id="8_ehrek"]
 [ext_resource type="Script" uid="uid://dt2p68xl462v2" path="res://Scripts/Parts/TextShadowColourChanger.gd" id="10_abjth"]
 
@@ -121,6 +123,100 @@ resource_setter = NodePath("ResourceSetterNew")
 [node name="ResourceSetterNew" type="Node" parent="BG/Control/Sprite"]
 script = ExtResource("5_mcaat")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
+
+[node name="ChallengeScore" type="Label" parent="BG/Control"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 0
+offset_left = -44.0
+offset_top = -11.0
+offset_right = 156.0
+offset_bottom = 5.0
+text = "CHALLENGE_DIALOGUE_SCORE"
+uppercase = true
+
+[node name="ChallengeScoreText" type="Label" parent="BG/Control"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 0
+offset_left = -8.0
+offset_top = -11.0
+offset_right = 56.0
+offset_bottom = 12.0
+text = "0"
+horizontal_alignment = 2
+
+[node name="Target" type="Label" parent="BG/Control/ChallengeScoreText"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -8.0
+offset_right = 8.0
+offset_bottom = 23.0
+theme_override_colors/font_color = Color(0.462745, 0.52549, 1, 1)
+text = "/00000"
+horizontal_alignment = 2
+
+[node name="ChallengeCoins2" type="Label" parent="BG/Control"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 0
+offset_left = -44.0
+offset_top = -27.0
+offset_right = 156.0
+offset_bottom = -11.0
+text = "CHALLENGE_DIALOGUE_COINS"
+uppercase = true
+
+[node name="ChallengeCoins" type="Node2D" parent="BG/Control"]
+unique_name_in_owner = true
+visible = false
+position = Vector2(20, -55)
+
+[node name="1" type="Sprite2D" parent="BG/Control/ChallengeCoins"]
+position = Vector2(-5, 36)
+texture = ExtResource("5_ehrek")
+hframes = 2
+region_rect = Rect2(8, 0, 8, 8)
+script = ExtResource("6_abjth")
+metadata/_custom_type_script = "uid://364rywt44hy6"
+
+[node name="2" type="Sprite2D" parent="BG/Control/ChallengeCoins"]
+position = Vector2(3, 36)
+texture = ExtResource("5_ehrek")
+hframes = 2
+frame = 1
+region_rect = Rect2(8, 0, 8, 8)
+script = ExtResource("6_abjth")
+metadata/_custom_type_script = "uid://364rywt44hy6"
+
+[node name="3" type="Sprite2D" parent="BG/Control/ChallengeCoins"]
+position = Vector2(11, 36)
+texture = ExtResource("5_ehrek")
+hframes = 2
+frame = 1
+region_rect = Rect2(8, 0, 8, 8)
+script = ExtResource("6_abjth")
+metadata/_custom_type_script = "uid://364rywt44hy6"
+
+[node name="4" type="Sprite2D" parent="BG/Control/ChallengeCoins"]
+position = Vector2(19, 36)
+texture = ExtResource("5_ehrek")
+hframes = 2
+frame = 1
+region_rect = Rect2(8, 0, 8, 8)
+script = ExtResource("6_abjth")
+metadata/_custom_type_script = "uid://364rywt44hy6"
+
+[node name="5" type="Sprite2D" parent="BG/Control/ChallengeCoins"]
+position = Vector2(27, 36)
+texture = ExtResource("5_ehrek")
+hframes = 2
+frame = 1
+region_rect = Rect2(8, 0, 8, 8)
+script = ExtResource("6_abjth")
+metadata/_custom_type_script = "uid://364rywt44hy6"
 
 [node name="Timer" type="Timer" parent="."]
 wait_time = 3.0

--- a/Scripts/Classes/UI/GameHUD.gd
+++ b/Scripts/Classes/UI/GameHUD.gd
@@ -42,6 +42,8 @@ func handle_main_hud() -> void:
 		update_character_info()
 	%CharacterIcon.get_node("Shadow").texture = %CharacterIcon.texture
 	%ModernLifeCount.text = "*" + (str(Global.lives).pad_zeros(2) if Settings.file.difficulty.inf_lives == 0 else "∞")
+	%CharacterIcon.visible = Global.current_game_mode != Global.GameMode.BOO_RACE
+	%ModernLifeCount.visible = Global.current_game_mode != Global.GameMode.BOO_RACE
 	var world_num := str(Global.world_num)
 	if int(world_num) >= 10:
 		world_num = ["A", "B", "C", "D"][int(world_num) % 10]
@@ -95,6 +97,8 @@ func handle_challenge_mode_hud() -> void:
 	$ModernHUD/TopLeft/RedCoins.show()
 	$ModernHUD/TopLeft/CoinCount.hide()
 	$Main/CoinCount.hide()
+	%ModernLifeCount.hide()
+	%CharacterIcon.hide()
 	var red_coins_collected = ChallengeModeHandler.current_run_red_coins_collected
 	var idx := 0
 	if Global.world_num > 8:

--- a/Scripts/Parts/LevelTransition.gd
+++ b/Scripts/Parts/LevelTransition.gd
@@ -84,7 +84,9 @@ func _ready() -> void:
 	elif Global.lives < 100:
 		$BG/Control/LivesCount.text = "* " + (str(Global.lives).lpad(2, " "))
 	else:
-		$BG/Control/LivesCount.text = "*  ♕" 
+		$BG/Control/LivesCount.text = "*  ♕"
+	if Global.current_game_mode == Global.GameMode.CHALLENGE:
+		handle_challenge_mode_transition()
 	if Global.current_game_mode == Global.GameMode.CUSTOM_LEVEL:
 		$BG/Control/World.hide()
 		$BG/Control/WorldNum.hide()
@@ -92,9 +94,29 @@ func _ready() -> void:
 		%CustomLevelName.show()
 		%CustomLevelAuthor.text = "By " + LevelEditor.level_author
 		%CustomLevelName.text = LevelEditor.level_name
+		
 	await get_tree().create_timer(0.1, false).timeout
 	can_transition = true
 
+func handle_challenge_mode_transition() -> void:
+	$BG/Control/LivesCount.hide()
+	$BG/Control/Sprite.hide()
+	%ChallengeScore.show()
+	%ChallengeScoreText.show()
+	%ChallengeScoreText/Target.show()
+	%ChallengeCoins2.show()
+	%ChallengeCoins.show()
+	%ChallengeScoreText.text = str(Global.score)
+	var idx = 0
+	for i in %ChallengeCoins.get_children():
+		if ChallengeModeHandler.is_coin_collected(idx, ChallengeModeHandler.red_coins_collected[Global.world_num - 1][Global.level_num - 1]):
+			i.frame = 1
+		else:
+			i.frame = 0
+		idx += 1
+	%ChallengeScoreText/Target.text = "/ " + str(ChallengeModeHandler.CHALLENGE_TARGETS[Global.current_campaign][Global.world_num - 1][Global.level_num - 1])
+
+	
 func transition() -> void:
 	Global.can_time_tick = true
 	if PIPE_CUTSCENE_LEVELS[Global.current_campaign].has([Global.world_num, Global.level_num]) and not PipeCutscene.seen_cutscene and Global.current_game_mode != Global.GameMode.MARATHON_PRACTICE and Global.current_game_mode !=Global.GameMode.BOO_RACE:


### PR DESCRIPTION
Lives don't do anything in challenge mode so I replaced the transition screen with one inspired by SMBDX. Also I removed lives from the modern hud for both challenge mode and you vs boo.
<img width="2556" height="1440" alt="screenshot_1760044634" src="https://github.com/user-attachments/assets/d5b57d69-7122-4c60-9a68-0edb00b559f3" />
