### PR TITLE
StarFall animation fallback fix

### DIFF
--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -170,7 +170,7 @@ const ANIMATION_FALLBACKS := {
 	"SwimBump": "Bump",
 	"DieFreeze": "Die",
 	"StarJump": "Jump",
-	"StarFall": "StarJump"
+	"StarFall": "JumpFall"
 }
 
 var palette_transform := true


### PR DESCRIPTION
if you don't have StarJump, it would ignore your JumpFall animation when you have invincibility. this fixes that.