### PR TITLE
Quick fixes for optional animations

### DIFF
--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -159,7 +159,7 @@ const ANIMATION_FALLBACKS := {
 	"WingCrouch": "WaterCrouch",
 	"CrouchFall": "Crouch", 
 	"CrouchJump": "Crouch", 
-	"CrouchBump": "Crouch",
+	"CrouchBump": "Bump",
 	"CrouchMove": "Crouch", 
 	"IdleAttack": "MoveAttack", 
 	"CrouchAttack": "IdleAttack", 
@@ -354,7 +354,6 @@ func camera_make_current() -> void:
 func play_animation(animation_name := "") -> void:
 	if sprite.sprite_frames == null: return
 	animation_name = get_fallback_animation(animation_name)
-	print(animation_name)
 	if sprite.animation != animation_name:
 		sprite.play(animation_name)
 
@@ -686,6 +685,10 @@ func set_power_state_frame() -> void:
 		$ResourceSetterNew.update_resource()
 	if %Sprite.sprite_frames != null:
 		can_pose = %Sprite.sprite_frames.has_animation("PoseDoor")
+		can_bump_jump = %Sprite.sprite_frames.has_animation("JumpBump")
+		can_bump_crouch = %Sprite.sprite_frames.has_animation("CrouchBump")
+		can_bump_swim = %Sprite.sprite_frames.has_animation("SwimBump")
+		can_bump_fly = %Sprite.sprite_frames.has_animation("FlyBump")
 		can_kick_anim = %Sprite.sprite_frames.has_animation("Kick")
 
 func get_power_up(power_name := "") -> void:

--- a/Scripts/Classes/States/Player/Normal.gd
+++ b/Scripts/Classes/States/Player/Normal.gd
@@ -212,7 +212,7 @@ func get_animation_name() -> String:
 	if player.kicking and player.can_kick_anim:
 		return "Kick"
 	if player.crouching and not wall_pushing:
-		if player.bumping:
+		if player.bumping and player.can_bump_crouch:
 			return "CrouchBump"
 		elif player.is_on_floor() == false:
 			if player.velocity.y >= 0:


### PR DESCRIPTION
This fixes an issue in which the run animations were flipped on accident and a fix for `CrouchBump`, which didn't use >= and thus resulted in a single `JumpFall` frame playing.