### PR TITLE
Quick remapping of SwimMove to WaterMove

### DIFF
--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -169,7 +169,7 @@ const ANIMATION_FALLBACKS := {
 	"SkidAttack": "MoveAttack",
 	"WingIdle": "WaterIdle",
 	"FlyUp": "SwimUp",
-	"WingMove": "SwimMove",
+	"WingMove": "WaterMove",
 	"FlyAttack": "SwimAttack",
 	"FlyBump": "SwimBump",
 	"FlagSlide": "Climb",


### PR DESCRIPTION
Fixes the fallback for WingMove to be set correctly to WaterMove. It does what it says on the tin.