### PR TITLE
Change default character on character variation key from 'Mario' to 'default'

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -273,7 +273,7 @@ func get_variation_json(json := {}) -> Dictionary:
 	
 	var chara = "Character:" + Player.CHARACTERS[int(Global.player_characters[0])]
 	if json.has(chara) == false:
-		chara = "Character:Mario"
+		chara = "Character:default"
 	if json.has(chara):
 		if json.get(chara).has("link"):
 			json = get_variation_json(json[json.get(chara).get("link")])


### PR DESCRIPTION
A very simple 1 line change that just fixes the character variation key which characters use as a default to use a proper "default" key rather than just Mario's. May require some JSON changes, but I'll check around and make sure to fix what I can find.