### PR TITLE
Fix Lakitu and deco not spawning in Challenge 8-2

### DIFF
--- a/Scenes/Levels/SMB1/World2/2-1.tscn
+++ b/Scenes/Levels/SMB1/World2/2-1.tscn
@@ -238,7 +238,7 @@ metadata/_custom_type_script = "uid://pfwgmuchergf"
 
 [node name="ChallengeNodes" type="Node" parent="." node_paths=PackedStringArray("nodes_to_delete")]
 script = ExtResource("27_nvjju")
-nodes_to_delete = [NodePath("../Blocks/QuestionBlock2"), null, NodePath("../Blocks/BrickBlock7")]
+nodes_to_delete = [NodePath("../Blocks/QuestionBlock2"), NodePath("../Blocks/BrickBlock7")]
 metadata/_custom_type_script = "uid://cgm3opb5qudc1"
 
 [node name="RedCoin" parent="ChallengeNodes" instance=ExtResource("28_t63mw")]

--- a/Scenes/Levels/SMB1/World3/3-2.tscn
+++ b/Scenes/Levels/SMB1/World3/3-2.tscn
@@ -164,9 +164,8 @@ position = Vector2(3192, 0)
 [node name="Checkpoint" parent="." instance=ExtResource("20_xv2tb")]
 position = Vector2(1328, 0)
 
-[node name="ChallengeNodes" type="Node" parent="." node_paths=PackedStringArray("nodes_to_delete")]
+[node name="ChallengeNodes" type="Node" parent="."]
 script = ExtResource("21_8rqg6")
-nodes_to_delete = [null]
 metadata/_custom_type_script = "uid://cgm3opb5qudc1"
 
 [node name="RedCoin" parent="ChallengeNodes" instance=ExtResource("22_cxldk")]

--- a/Scenes/Levels/SMB1/World4/4-1.tscn
+++ b/Scenes/Levels/SMB1/World4/4-1.tscn
@@ -112,7 +112,7 @@ tile_map_data = PackedByteArray("AAD7////AAAAAAAAAAD8////AAABAAAAAAD+////AAABAAA
 
 [node name="ChallengeNodes" type="Node" parent="." node_paths=PackedStringArray("nodes_to_delete")]
 script = ExtResource("21_f001g")
-nodes_to_delete = [NodePath("../Blocks/QuestionBlock3"), NodePath("../Coin"), null, NodePath("../Blocks/QuestionBlock4")]
+nodes_to_delete = [NodePath("../Blocks/QuestionBlock3"), NodePath("../Coin"), NodePath("../Blocks/QuestionBlock4")]
 metadata/_custom_type_script = "uid://cgm3opb5qudc1"
 
 [node name="QuestionBlock" parent="ChallengeNodes" instance=ExtResource("9_vtupl")]

--- a/Scenes/Levels/SMB1/World7/7-3.tscn
+++ b/Scenes/Levels/SMB1/World7/7-3.tscn
@@ -1054,7 +1054,7 @@ position = Vector2(2976, -96)
 [node name="InvisibleQuestionBlock" parent="ChallengeNodes" index="5"]
 position = Vector2(504, -104)
 
-[node name="InvisibleQuestionBlock2" parent="ChallengeNodes" index="6" instance=ExtResource("3_dfskb")]
+[node name="InvisibleQuestionBlock3" parent="ChallengeNodes" index="6" instance=ExtResource("3_dfskb")]
 position = Vector2(1176, -104)
 
 [node name="Enemies" type="Node" parent="." index="13"]

--- a/Scenes/Levels/SMB1/World8/8-2.tscn
+++ b/Scenes/Levels/SMB1/World8/8-2.tscn
@@ -185,7 +185,7 @@ optional = true
 
 [node name="ChallengeNodes" type="Node" parent="." node_paths=PackedStringArray("nodes_to_delete")]
 script = ExtResource("20_8cbri")
-nodes_to_delete = [NodePath("../Enemies/Lakitu"), NodePath("../DecoTiles"), NodePath("../Blocks")]
+nodes_to_delete = [NodePath("../Blocks")]
 force_on = true
 metadata/_custom_type_script = "uid://cgm3opb5qudc1"
 


### PR DESCRIPTION
Fixes #582 
For some reason in online maps the Lakitu isn't there, which is probably why we accidentally had it removed, but I actually looked in SMBDX and the Lakitu is there so we and the map had it wrong. Also for some reason Challenge mode removed all the deco tiles in the stage, which was obviously a mistake (the deco IS there in smbdx).
I also did some tiny cleanup when looking through all the stages for any other possible instances of this, but this seems to be the only one.