### PR TITLE
Some Fake Bowser Fixes

### DIFF
--- a/Scenes/Prefabs/Entities/Enemies/Bowser.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/Bowser.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=3 uid="uid://duptcik2j0b04"]
+[gd_scene load_steps=40 format=3 uid="uid://duptcik2j0b04"]
 
 [ext_resource type="Texture2D" uid="uid://d3sxabber73q6" path="res://Assets/Sprites/Enemies/Bowser.png" id="1_8mi7o"]
 [ext_resource type="Script" uid="uid://wtypg4d0l6j2" path="res://Scripts/Classes/Entities/Enemies/Bowser.gd" id="1_ma5fd"]
@@ -11,7 +11,6 @@
 [ext_resource type="JSON" path="res://Assets/Sprites/Enemies/Bowser.json" id="6_nf6hu"]
 [ext_resource type="Script" uid="uid://cmvlgsjmsk0v5" path="res://Scripts/Classes/Resources/ThemedResource.gd" id="6_pvhfi"]
 [ext_resource type="Script" uid="uid://c3gg32ivrlq8n" path="res://Scripts/Classes/Components/GibSpawner.gd" id="6_va0n6"]
-[ext_resource type="JSON" path="res://Assets/Sprites/Enemies/Goomba.json" id="9_exf4b"]
 [ext_resource type="Script" uid="uid://5octqlf4ohel" path="res://Scripts/Classes/Components/ScoreNoteSpawner.gd" id="11_pvhfi"]
 [ext_resource type="Script" uid="uid://cqif1li7otvpl" path="res://Scripts/Parts/SpriteFramesToJsonConverter.gd" id="14_nf6hu"]
 [ext_resource type="Script" uid="uid://ctfbuoxtnnl0q" path="res://Scripts/Classes/Components/EditorPropertyExposer.gd" id="15_nf6hu"]
@@ -300,7 +299,7 @@ metadata/_custom_type_script = "uid://caq1qiwmy0mox"
 script = ExtResource("5_17x2r")
 node_to_affect = NodePath("..")
 property_name = "sprite_frames"
-resource_json = ExtResource("9_exf4b")
+resource_json = ExtResource("6_nf6hu")
 use_cache = false
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
@@ -344,6 +343,7 @@ metadata/_custom_type_script = "uid://dri2d5jtu0fbq"
 [node name="GibSpawner" type="Node" parent="." node_paths=PackedStringArray("visuals")]
 script = ExtResource("6_va0n6")
 visuals = NodePath("../SpriteScaleJoint/DeathSprite")
+gib_type = 1
 metadata/_custom_type_script = "uid://c3gg32ivrlq8n"
 
 [node name="ScoreNoteSpawner" type="Node" parent="."]
@@ -403,13 +403,14 @@ hitbox = NodePath("../SpriteScaleJoint/Sprite/Hitbox")
 metadata/_custom_type_script = "uid://ba18grqjixded"
 
 [connection signal="killed" from="." to="GibSpawner" method="summon_gib"]
-[connection signal="killed" from="." to="." method="show_smoke" unbinds=1]
 [connection signal="killed" from="." to="ScoreNoteSpawner" method="spawn_note" binds= [5000]]
+[connection signal="killed" from="." to="." method="show_smoke" unbinds=1]
 [connection signal="area_entered" from="SpriteScaleJoint/Sprite/Hitbox" to="." method="on_area_entered"]
 [connection signal="timeout" from="JumpTimer" to="." method="jump"]
 [connection signal="timeout" from="HammerTime" to="." method="throw_hammers"]
 [connection signal="timeout" from="FlameTimer" to="." method="breathe_fire"]
 [connection signal="fireball_hit" from="FireballDetection" to="." method="fireball_hit" unbinds=1]
+[connection signal="gib_about_to_spawn" from="GibSpawner" to="." method="on_gib_about_to_spawn"]
 [connection signal="screen_entered" from="VisibleOnScreenEnabler2D" to="." method="play_music" flags=6]
 [connection signal="attached" from="TrackJoint" to="MoveAnimation" method="play" binds= ["RESET"]]
 [connection signal="moving_shell_entered" from="ShellDetection" to="ShellDetection" method="destroy_shell"]

--- a/Scenes/Prefabs/Entities/Enemies/BowsersBro.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/BowsersBro.tscn
@@ -11,3 +11,6 @@ resource_json = ExtResource("2_qcxx5")
 
 [node name="ResourceSetterNew" parent="SpriteScaleJoint/DeathSprite" index="0"]
 resource_json = ExtResource("2_qcxx5")
+
+[node name="GibSpawner" parent="." index="8" node_paths=PackedStringArray("visuals")]
+visuals = NodePath("../SpriteScaleJoint/DeathSprite")

--- a/Scenes/Prefabs/Entities/Enemies/TrueBowser.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/TrueBowser.tscn
@@ -5,7 +5,7 @@
 
 [node name="TrueBowser" instance=ExtResource("1_xtf8a")]
 can_hammer = true
-metadata/is_real = true
+is_real = true
 
 [node name="ResourceSetterNew" parent="SpriteScaleJoint/DeathSprite" index="0"]
 resource_json = ExtResource("4_ryqkh")

--- a/Scripts/Classes/Entities/Enemies/Bowser.gd
+++ b/Scripts/Classes/Entities/Enemies/Bowser.gd
@@ -50,15 +50,12 @@ func get_target_y(player: Player) -> float:
 		return player.global_position.y - 8
 
 func show_smoke() -> void:
-	# guzlad: ugly but it'll have to do until we move the metadata stuff to actual variables
-	if (((Global.current_game_mode == Global.GameMode.CUSTOM_LEVEL) or (Global.current_game_mode == Global.GameMode.LEVEL_EDITOR)) and !is_real):
-		var smoke = preload("res://Scenes/Prefabs/Particles/SmokeParticle.tscn").instantiate()
-		smoke.scale = Vector2(2, 2)
-		smoke.global_position =global_position
-		AudioManager.play_sfx("magic", global_position)
-		add_sibling(smoke)
-	elif has_meta("is_real"):
-		return
+	if is_real: return
+	var smoke = preload("res://Scenes/Prefabs/Particles/SmokeParticle.tscn").instantiate()
+	smoke.scale = Vector2(2, 2)
+	smoke.global_position =global_position
+	AudioManager.play_sfx("magic", global_position)
+	add_sibling(smoke)
 
 func breathe_fire() -> void:
 	if can_fire == false:
@@ -133,7 +130,8 @@ func fireball_hit() -> void:
 func play_music() -> void:
 	for i: EntityGenerator in get_tree().get_nodes_in_group("EntityGenerators"):
 		if i.entity_scene != null:
-			if i.entity_scene.resource_path == "res://Scenes/Prefabs/Entities/Enemies/BowserFlame.tscn":
+			if i.entity_scene.resource_path == "res://Scenes/
+			Prefabs/Entities/Enemies/BowserFlame.tscn":
 				i.queue_free()
 	if Settings.file.audio.extra_bgm == 0: return
 	if Global.level_editor != null:
@@ -141,6 +139,14 @@ func play_music() -> void:
 	if music_enabled:
 		AudioManager.set_music_override(AudioManager.MUSIC_OVERRIDES.BOWSER, 5, false)
 
-
 func on_timeout() -> void:
 	move_dir = [-1, 1].pick_random()
+
+func on_gib_about_to_spawn() -> void:
+	if is_real:
+		$FallSFX.play()
+		$FallSFX.finished.connect($FallSFX.queue_free)
+		$FallSFX.reparent(get_parent())
+	# guzlad: ugly but it'll have to do until we move the metadata stuff to actual variables
+	if ((Global.current_game_mode == Global.GameMode.CUSTOM_LEVEL) or (Global.current_game_mode == Global.GameMode.LEVEL_EDITOR)) and !is_real:
+		$SpriteScaleJoint/DeathSprite/ResourceSetterNew.resource_json = load("res://Assets/Sprites/Enemies/Goomba.json")


### PR DESCRIPTION
This PR fixes the issues mentioned in #557 with Fake and Real Bowsers. This also gives Fake Bowsers the same death trajectory as the real ones to reflect SMB.
Also, for fun, I got the Bowser fall SFX to work when you kill a REAL Bowser or Bowser Bro by moving it outside of Bowser before they were freed from the scene. I decided not to do that for the Fake Bowsers since there's already a Poof sound effect that plays.

https://github.com/user-attachments/assets/480d2508-f19b-4dbe-97a5-fe1b048097ba
