### PR TITLE
Make the rest of the credits images pack replacable

### DIFF
--- a/Scenes/Levels/Credits.tscn
+++ b/Scenes/Levels/Credits.tscn
@@ -427,7 +427,6 @@ stretch_mode = 2
 script = ExtResource("11_d4vu4")
 metadata/_custom_type_script = "uid://ca3bew33g45eq"
 
-
 [node name="Label5" type="Label" parent="Labels/TileArtists/Label"]
 layout_mode = 0
 offset_top = 80.0
@@ -1829,7 +1828,6 @@ script = ExtResource("11_d4vu4")
 metadata/_custom_type_script = "uid://ca3bew33g45eq"
 
 [node name="TextureRect" type="TextureRect" parent="Labels/Localizers"]
-visible = false
 layout_mode = 0
 offset_left = 120.0
 offset_top = 8.0


### PR DESCRIPTION
It seems someone started it but stopped half way through, so I finished it. Now all images in the credits can be replaced by resource packs.