### PR TITLE
 Fix Underground BG not animating

### DIFF
--- a/Assets/Sprites/Backgrounds/Hills/Hill.json
+++ b/Assets/Sprites/Backgrounds/Hills/Hill.json
@@ -67,7 +67,7 @@
 		"Underground": {
 			"SMB1": {
 				"source": "Underground.png",
-				"animations": {
+				"animation_overrides": {
 					"default": {
 						"frames": [
 							[
@@ -90,7 +90,7 @@
 			},
 			"SMBLL": {
 				"source": "UndergroundLL.png",
-				"animations": {
+				"animation_overrides": {
 					"default": {
 						"frames": [
 							[


### PR DESCRIPTION
this was an issue because of "animation_overrides" now being mandatory to give a variation its own animation, when an existing animation is in the same JSON.