### PR TITLE
Make Pokey slower + make Pokey and Dry Bones turn at ledges

### DIFF
--- a/Scenes/Prefabs/Entities/Enemies/DryBones.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/DryBones.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://bxsay5e6dhcqb"]
+[gd_scene load_steps=26 format=3 uid="uid://bxsay5e6dhcqb"]
 
 [ext_resource type="Script" uid="uid://n123x5yuqpjd" path="res://Scripts/Classes/Entities/Enemies/DryBones.gd" id="1_8c647"]
 [ext_resource type="Texture2D" uid="uid://c5snfukhcacyf" path="res://Assets/Sprites/Enemies/DryBones.png" id="2_qya46"]
@@ -11,6 +11,7 @@
 [ext_resource type="Script" uid="uid://5octqlf4ohel" path="res://Scripts/Classes/Components/ScoreNoteSpawner.gd" id="7_qya46"]
 [ext_resource type="Script" uid="uid://dlq6o2rg1x7in" path="res://Scripts/Classes/Components/BasicEnemyMovement.gd" id="10_br3pe"]
 [ext_resource type="Script" uid="uid://ba18grqjixded" path="res://Scripts/Classes/Components/ExplosionDetection.gd" id="11_l4h6l"]
+[ext_resource type="Script" uid="uid://blfnd65xcx78c" path="res://Scripts/Classes/Components/LedgeDetectionCast.gd" id="12_w4qtl"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_w4qtl"]
 atlas = ExtResource("2_qya46")
@@ -196,13 +197,21 @@ rect = Rect2(-10, -13, 20, 23)
 script = ExtResource("7_qya46")
 metadata/_custom_type_script = "uid://5octqlf4ohel"
 
-[node name="BasicEnemyMovement" type="Node" parent="."]
+[node name="BasicEnemyMovement" type="Node" parent="." node_paths=PackedStringArray("ledge_detection_cast")]
 script = ExtResource("10_br3pe")
+ledge_detection_cast = NodePath("../LedgeDetectionCast")
 
 [node name="ExplosionDetection" type="Node" parent="." node_paths=PackedStringArray("hitbox")]
 script = ExtResource("11_l4h6l")
 hitbox = NodePath("../Hitbox")
 metadata/_custom_type_script = "uid://ba18grqjixded"
+
+[node name="LedgeDetectionCast" type="RayCast2D" parent="."]
+position = Vector2(-2, -2)
+target_position = Vector2(0, 3)
+collision_mask = 2
+script = ExtResource("12_w4qtl")
+metadata/_custom_type_script = "uid://blfnd65xcx78c"
 
 [connection signal="killed" from="." to="." method="summon_particle" unbinds=1]
 [connection signal="hammer_player_hit" from="EnemyPlayerDetection" to="." method="die_from_hammer"]

--- a/Scenes/Prefabs/Entities/Enemies/Pokey.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/Pokey.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://beggmeixrin75"]
+[gd_scene load_steps=23 format=3 uid="uid://beggmeixrin75"]
 
 [ext_resource type="Script" uid="uid://b1b6aiai213ci" path="res://Scripts/Classes/Entities/Enemies/Pokey.gd" id="1_b54ls"]
 [ext_resource type="Texture2D" uid="uid://dj46y8vhqlqjw" path="res://Assets/Sprites/Enemies/Pokey.png" id="2_8aome"]
@@ -15,6 +15,7 @@
 [ext_resource type="Script" uid="uid://dlq6o2rg1x7in" path="res://Scripts/Classes/Components/BasicEnemyMovement.gd" id="11_8aome"]
 [ext_resource type="Script" uid="uid://5octqlf4ohel" path="res://Scripts/Classes/Components/ScoreNoteSpawner.gd" id="12_b54ls"]
 [ext_resource type="Script" uid="uid://ctfbuoxtnnl0q" path="res://Scripts/Classes/Components/EditorPropertyExposer.gd" id="13_30hxr"]
+[ext_resource type="Script" uid="uid://blfnd65xcx78c" path="res://Scripts/Classes/Components/LedgeDetectionCast.gd" id="16_rjgwh"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g6vo0"]
 atlas = ExtResource("2_8aome")
@@ -357,8 +358,9 @@ shape = SubResource("RectangleShape2D_mpg4k")
 position = Vector2(0, -168)
 rect = Rect2(-10, 0, 20, 176)
 
-[node name="BasicEnemyMovement" type="Node" parent="." node_paths=PackedStringArray("visuals")]
+[node name="BasicEnemyMovement" type="Node" parent="." node_paths=PackedStringArray("ledge_detection_cast", "visuals")]
 script = ExtResource("11_8aome")
+ledge_detection_cast = NodePath("../LedgeDetectionCast")
 move_speed = 16
 second_quest_speed = 20
 visuals = NodePath("../Parts")
@@ -376,6 +378,12 @@ properties = Array[String](["length"])
 [node name="PartHandler" type="Node" parent="."]
 process_mode = 3
 script = SubResource("GDScript_30hxr")
+
+[node name="LedgeDetectionCast" type="RayCast2D" parent="."]
+position = Vector2(-4, -5)
+target_position = Vector2(0, 8)
+collision_mask = 2
+script = ExtResource("16_rjgwh")
 
 [connection signal="killed" from="." to="." method="summon_part_gibs" unbinds=1]
 [connection signal="fireball_hit" from="FireballDetection" to="." method="die_from_object"]


### PR DESCRIPTION
In SMM2, Pokeys are half as fast as Goombas. So I did that here.
Also in SMM2, Pokeys and Dry Bones turn at ledges, so I also did that.
Fixes #240