### PR TITLE
Fix not being able to collect Red Coins from bumping blocks

### DIFF
--- a/Scenes/Prefabs/Entities/Items/RedCoin.tscn
+++ b/Scenes/Prefabs/Entities/Items/RedCoin.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://cmbpqnq10arts"]
+[gd_scene load_steps=19 format=3 uid="uid://cmbpqnq10arts"]
 
 [ext_resource type="Script" uid="uid://xwq5ac650e76" path="res://Scripts/Classes/Entities/Items/RedCoin.gd" id="1_c6tmk"]
 [ext_resource type="Texture2D" uid="uid://c8wpxm7b5tgiq" path="res://Assets/Sprites/Items/RedCoin.png" id="2_lwdcj"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://cbal8ms2oe1ik" path="res://Scripts/Classes/Components/ResourceSetterNew.gd" id="3_0xloa"]
 [ext_resource type="Script" uid="uid://cmg61722ktg2m" path="res://Scripts/Classes/Components/BlockBouncingDetection.gd" id="4_lwdcj"]
 [ext_resource type="JSON" path="res://Assets/Sprites/Items/RedCoin.json" id="5_0fjrw"]
+[ext_resource type="Script" uid="uid://maqpreddu5kg" path="res://Scripts/Classes/Components/LevelPersistance.gd" id="7_0r8d3"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lwdcj"]
 atlas = ExtResource("2_lwdcj")
@@ -79,6 +80,9 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4qu2r"]
 size = Vector2(12, 15)
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_0xloa"]
+size = Vector2(8, 8)
+
 [node name="RedCoin" type="Node2D"]
 visibility_layer = 3
 z_index = -2
@@ -110,8 +114,21 @@ shape = SubResource("RectangleShape2D_4qu2r")
 [node name="BlockBouncingDetection" type="Node" parent="." node_paths=PackedStringArray("hitbox")]
 script = ExtResource("4_lwdcj")
 detection_type = 1
-hitbox = NodePath("")
+hitbox = NodePath("../BlockHitbox")
 metadata/_custom_type_script = "uid://cmg61722ktg2m"
 
+[node name="BlockHitbox" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 6
+
+[node name="Shape" type="CollisionShape2D" parent="BlockHitbox"]
+position = Vector2(0, 12)
+shape = SubResource("RectangleShape2D_0xloa")
+
+[node name="LevelPersistance" type="Node" parent="."]
+script = ExtResource("7_0r8d3")
+
+[connection signal="collected" from="." to="LevelPersistance" method="set_as_active"]
 [connection signal="area_entered" from="Hitbox" to="." method="on_area_entered"]
 [connection signal="block_bounced" from="BlockBouncingDetection" to="." method="summon_bounced_coin" unbinds=1]
+[connection signal="enabled" from="LevelPersistance" to="." method="queue_free"]

--- a/Scripts/Classes/Entities/Items/RedCoin.gd
+++ b/Scripts/Classes/Entities/Items/RedCoin.gd
@@ -8,6 +8,8 @@ var can_spawn_particles := false
 
 @onready var COIN_SPARKLE = load("res://Scenes/Prefabs/Particles/RedCoinSparkle.tscn")
 
+signal collected
+
 func _ready() -> void:
 	if ChallengeModeHandler.is_coin_collected(id):
 		already_collected = true
@@ -16,9 +18,10 @@ func _ready() -> void:
 
 func on_area_entered(area: Area2D) -> void:
 	if area.owner is Player:
-		collected()
+		collect()
 
-func collected() -> void:
+func collect() -> void:
+	collected.emit()
 	if already_collected:
 		AudioManager.play_sfx("coin", global_position, 2)
 	else:


### PR DESCRIPTION
Like regular coins, red coins in SMBDX also get collected if you bump a brick block beneath them. It seems it was planned to be added but it was half-implemented and forgotten, so I just added the rest of the stuff needed.