### PR TITLE
Simple snapshot tools

### DIFF
--- a/Scenes/Levels/TitleScreen.tscn
+++ b/Scenes/Levels/TitleScreen.tscn
@@ -917,12 +917,11 @@ color = Color(0, 0, 0, 1)
 autostart = true
 
 [node name="DevBuildWarning" type="Label" parent="CanvasLayer2/VersionLabel"]
-visible = false
-layout_mode = 1
-offset_top = 16.0
-offset_right = 56.0
-offset_bottom = 32.0
-text = "DEVELOPMENT BUILD! EXPECT BUGS!"
+layout_mode = 0
+offset_top = 14.0
+offset_right = 128.0
+offset_bottom = 30.0
+text = "SNAPSHOT BUILD - EXPECT BUGS!"
 uppercase = true
 
 [node name="ColorRect" type="ColorRect" parent="CanvasLayer2/VersionLabel/DevBuildWarning"]
@@ -934,7 +933,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0, 0, 0, 1)
+color = Color(0, 0, 0, 0.49803922)
 
 [node name="DropShadow" parent="." instance=ExtResource("5_8t4ah")]
 

--- a/Scripts/Parts/TitleScreen.gd
+++ b/Scripts/Parts/TitleScreen.gd
@@ -27,6 +27,7 @@ func _enter_tree() -> void:
 
 func _ready() -> void:
 	setup_stars()
+	$CanvasLayer2/VersionLabel/DevBuildWarning.visible = Global.is_snapshot
 	Global.level_theme_changed.connect(setup_stars)
 	DiscoLevel.in_disco_level = false
 	get_tree().paused = false


### PR DESCRIPTION
Variable for easily toggling on and off snapshot mode, and also some simple prints for things like unix time and what snapshot build the game would currently be on upon launch. The snapshot label which appears is also modified to be a little more accurate in description and a little less intrusive.

If possible I would have liked to make it so when snapshot mode is enabled it would update the version number accordingly upon building the game, but I couldn't figure it out. Would be nice to have though, so then you don't have to worry about updating version.txt every time a snapshot needs to be released.

<img width="270" height="78" alt="image" src="https://github.com/user-attachments/assets/dd11113d-7d6e-45a8-a13b-f98889ec29a3" />
