### PR TITLE
Allow `choices` and `config` variation keys to use `link`s

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -204,7 +204,11 @@ func get_variation_json(json := {}) -> Dictionary:
 		if config_to_use != {}:
 			var option_name = i.get_slice(":", 1)
 			if config_to_use.options.has(option_name):
-				json = get_variation_json(json[i][config_to_use.options[option_name]])
+				var config_json = json[i][config_to_use.options[option_name]]
+				if config_json.has("link"):
+					json = get_variation_json(json[config_json.get("link")])
+				else:
+					json = get_variation_json(config_json)
 				break
 	
 	if json.has(level_theme) == false:
@@ -234,7 +238,11 @@ func get_variation_json(json := {}) -> Dictionary:
 	
 	if json.has("choices"):
 		is_random = true
-		json = get_variation_json(json.choices.pick_random())
+		var random_json = json.choices.pick_random()
+		if random_json.has("link"):
+			json = get_variation_json(json[random_json.get("link")])
+		else:
+			json = get_variation_json(random_json)
 	
 	var world = "World" + str(Global.world_num)
 	if force_properties.has("World"):


### PR DESCRIPTION
They didn't before, now they do. (Do note that the linked keys have to be located next to the `config`/`choices` key, just like all other links.)
Example resource pack: [choices_config_links.zip](https://github.com/user-attachments/files/23167395/choices_config_links.zip) (changes the color of the "Remastered" logo on the title screen according to a config option, and adds some text to it randomly)

https://github.com/user-attachments/assets/a6acc85e-5890-4489-8e52-d8d763578f7d

<img width="1013" height="866" alt="image" src="https://github.com/user-attachments/assets/d81d3253-13d4-400e-af02-a2327363c99b" />
