### PR TITLE
Fix for SMBS Marathon achievements not being achievable.

### DIFF
--- a/Scripts/Classes/Singletons/SpeedrunHandler.gd
+++ b/Scripts/Classes/Singletons/SpeedrunHandler.gd
@@ -123,7 +123,6 @@ const SMBLL_LEVEL_GOLD_ANY_TIMES := {
 }
 
 const SMBS_LEVEL_GOLD_ANY_TIMES := {
-	"1-2": 25,
 	"4-2": 30
 }
 


### PR DESCRIPTION
Removes an extraneous any% time that doesn't exist in SMBS to allow for the player to actually complete the achievements for marathon mode in SMBS.