### PR TITLE
Audio file extension check fix

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -347,14 +347,14 @@ func load_image_from_path(path := "") -> Texture2D:
 
 func load_audio_from_path(path := "") -> AudioStream:
 	var stream = null
-	if path.contains(".bgm"):
+	if path.get_extension(".bgm"):
 		stream = AudioManager.generate_interactive_stream(JSON.parse_string(FileAccess.get_file_as_string(path)))
 	elif path.contains("res://"):
 		return load(path)
-	if path.contains(".wav"):
+	if path.get_extension(".wav"):
 		stream = AudioStreamWAV.load_from_file(path)
-	elif path.contains(".mp3"):
+	elif path.get_extension(".mp3"):
 		stream = AudioStreamMP3.load_from_file(path)
-	elif path.contains(".ogg"):
+	elif path.get_extension(".ogg"):
 		stream = AudioStreamOggVorbis.load_from_file(path)
 	return stream


### PR DESCRIPTION
This fixes audio extensions not getting correctly detected under circumstances like titles containing extension names. For example, "slop.mp3.ogg" would get detected as an .mp3 file rather than an .ogg, since it only checks if the path contains it rather than checking the extension.