### PR TITLE
Ignore Mods in GitHub (Dev PR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .godot/
 /android/
 Exports/
+
+# SMB1R specific ignores
+/mods
+/mods-unpacked
 Assets/LevelGuides
 addons/discord-rpc-gd/bin/windows/~discord_game_sdk_binding_debug.dll
 godotgif/bin/~godotgif.windows.template_debug.x86_64.dll


### PR DESCRIPTION
Excludes the Mods folders from the GitHub. Don't want to accidentally commit mods directly into the repo. Includes both the `mods` and `mods-unpacked` folders