### PR TITLE
Switch the flight meter to a proper Wing timer

### DIFF
--- a/Scenes/Prefabs/Entities/Player.tscn
+++ b/Scenes/Prefabs/Entities/Player.tscn
@@ -410,6 +410,11 @@ script = ExtResource("24_hu5lw")
 Overworld = ExtResource("13_uo1a1")
 metadata/_custom_type_script = "uid://cmvlgsjmsk0v5"
 
+[sub_resource type="Resource" id="Resource_xy8gq"]
+script = ExtResource("24_hu5lw")
+Overworld = ExtResource("40_o70e0")
+metadata/_custom_type_script = "uid://cmvlgsjmsk0v5"
+
 [sub_resource type="Resource" id="Resource_cekpg"]
 script = ExtResource("24_hu5lw")
 Overworld = ExtResource("18_hofol")
@@ -477,11 +482,6 @@ size = Vector2(4, 6.75)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_34tqy"]
 resource_local_to_scene = true
 size = Vector2(4, 12)
-
-[sub_resource type="Resource" id="Resource_xy8gq"]
-script = ExtResource("24_hu5lw")
-Overworld = ExtResource("40_o70e0")
-metadata/_custom_type_script = "uid://cmvlgsjmsk0v5"
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_pm4ir"]
 particles_animation = true
@@ -761,11 +761,6 @@ texture = ExtResource("20_34tqy")
 script = ExtResource("8_4ojwh")
 metadata/_custom_type_script = "uid://5octqlf4ohel"
 
-[node name="StarTimer" type="Timer" parent="."]
-process_mode = 1
-wait_time = 10.0
-one_shot = true
-
 [node name="Checkpoint" type="Sprite2D" parent="."]
 process_mode = 3
 physics_interpolation_mode = 2
@@ -800,10 +795,32 @@ property_name = "texture"
 themed_resource = SubResource("Resource_2mfvl")
 metadata/_custom_type_script = "uid://cq6f682453q6o"
 
+[node name="StarTimer" type="Timer" parent="."]
+process_mode = 1
+wait_time = 10.0
+one_shot = true
+
+[node name="WingTimer" type="Timer" parent="."]
+process_mode = 1
+wait_time = 10.0
+one_shot = true
+
 [node name="HammerTimer" type="Timer" parent="."]
 process_mode = 1
 wait_time = 10.0
 one_shot = true
+
+[node name="TimerWarn" type="AudioStreamPlayer" parent="."]
+process_mode = 3
+stream = ExtResource("40_o70e0")
+bus = &"SFX"
+
+[node name="ResourceSetter" type="Node" parent="TimerWarn" node_paths=PackedStringArray("node_to_affect")]
+script = ExtResource("27_6ws8x")
+node_to_affect = NodePath("..")
+property_name = "stream"
+themed_resource = SubResource("Resource_xy8gq")
+metadata/_custom_type_script = "uid://cq6f682453q6o"
 
 [node name="SkidSFX" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("18_hofol")
@@ -969,7 +986,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 mouse_filter = 2
 
-[node name="TimerSprite" type="Sprite2D" parent="CanvasLayer/Control2/MarginContainer/Timers/WingTimer" node_paths=PackedStringArray("warn_sfx")]
+[node name="TimerSprite" type="Sprite2D" parent="CanvasLayer/Control2/MarginContainer/Timers/WingTimer" node_paths=PackedStringArray("timer", "warn_sfx")]
 texture = ExtResource("29_uwhl4")
 centered = false
 hframes = 7
@@ -977,8 +994,9 @@ region_enabled = true
 region_rect = Rect2(0, 16, 56, 8)
 script = ExtResource("30_o70e0")
 max_value = 10.0
-value_name = "flight_meter"
-object = 1
+value_name = "time_left"
+object = 2
+timer = NodePath("../../../../../../WingTimer")
 warn_sfx = NodePath("../../../../../../TimerWarn")
 warn_threshold = 0.8500000000058208
 metadata/_custom_type_script = "uid://dn5efttgugwvb"
@@ -1114,18 +1132,6 @@ script = ExtResource("21_jl70t")
 link = NodePath("../../BigCollision")
 metadata/scalable = false
 
-[node name="TimerWarn" type="AudioStreamPlayer" parent="."]
-process_mode = 3
-stream = ExtResource("40_o70e0")
-bus = &"SFX"
-
-[node name="ResourceSetter" type="Node" parent="TimerWarn" node_paths=PackedStringArray("node_to_affect")]
-script = ExtResource("27_6ws8x")
-node_to_affect = NodePath("..")
-property_name = "stream"
-themed_resource = SubResource("Resource_xy8gq")
-metadata/_custom_type_script = "uid://cq6f682453q6o"
-
 [node name="SkidParticles" type="CPUParticles2D" parent="."]
 unique_name_in_owner = true
 material = SubResource("CanvasItemMaterial_pm4ir")
@@ -1143,5 +1149,6 @@ anim_speed_max = 1.0
 [connection signal="area_entered" from="Hitbox" to="." method="on_area_entered"]
 [connection signal="area_exited" from="Hitbox" to="." method="on_area_exited"]
 [connection signal="body_entered" from="LavaPoisonDetect" to="." method="die" unbinds=1]
-[connection signal="timeout" from="StarTimer" to="." method="on_timeout"]
+[connection signal="timeout" from="StarTimer" to="." method="on_star_timeout"]
+[connection signal="timeout" from="WingTimer" to="." method="on_wing_timeout"]
 [connection signal="timeout" from="HammerTimer" to="." method="on_hammer_timeout"]

--- a/Scripts/Classes/States/Player/Normal.gd
+++ b/Scripts/Classes/States/Player/Normal.gd
@@ -42,7 +42,7 @@ func handle_movement(delta: float) -> void:
 		player_transform.origin += Vector2.UP * 1
 	if player.is_actually_on_floor():
 		handle_ground_movement(delta)
-	elif player.in_water or player.flight_meter > 0:
+	elif player.in_water or player.has_wing:
 		handle_swimming(delta)
 	else:
 		handle_air_movement(delta)
@@ -55,12 +55,12 @@ func grounded(delta: float) -> void:
 		player.has_jumped = false
 	if Global.player_action_just_pressed("jump", player.player_id):
 		player.handle_water_detection()
-		if player.in_water or player.flight_meter > 0:
+		if player.in_water or player.has_wing:
 			swim_up()
 			return
 		else:
 			player.jump()
-	if jump_queued and not (player.in_water or player.flight_meter > 0):
+	if jump_queued and not (player.in_water or player.has_wing):
 		if player.spring_bouncing == false:
 			player.jump()
 		jump_queued = false
@@ -94,10 +94,10 @@ func handle_ground_movement(delta: float) -> void:
 
 func ground_acceleration(delta: float) -> void:
 	var target_move_speed := player.WALK_SPEED
-	if player.in_water or player.flight_meter > 0:
+	if player.in_water or player.has_wing:
 		target_move_speed = player.SWIM_GROUND_SPEED
 	var target_accel := player.GROUND_WALK_ACCEL
-	if (Global.player_action_pressed("run", player.player_id) and abs(player.velocity.x) >= player.WALK_SPEED) and (not player.in_water and player.flight_meter <= 0) and player.can_run:
+	if (Global.player_action_pressed("run", player.player_id) and abs(player.velocity.x) >= player.WALK_SPEED) and (not player.in_water and not player.has_wing) and player.can_run:
 		target_move_speed = player.RUN_SPEED
 		target_accel = player.GROUND_RUN_ACCEL
 	if player.input_direction != player.velocity_direction:
@@ -120,7 +120,7 @@ func ground_skid(delta: float) -> void:
 
 func in_air() -> void:
 	if Global.player_action_just_pressed("jump", player.player_id):
-		if player.in_water or player.flight_meter > 0:
+		if player.in_water or player.has_wing:
 			swim_up()
 		else:
 			jump_queued = true
@@ -149,7 +149,7 @@ func air_skid(delta: float) -> void:
 
 func handle_swimming(delta: float) -> void:
 	bubble_meter += delta
-	if bubble_meter >= 1 and player.flight_meter <= 0:
+	if bubble_meter >= 1 and not player.has_wing:
 		player.summon_bubble()
 		bubble_meter = 0
 	swim_up_meter -= delta
@@ -173,7 +173,7 @@ func swim_up() -> void:
 	player.crouching = false
 
 func handle_animations() -> void:
-	if (player.is_actually_on_floor() or player.in_water or player.flight_meter > 0 or player.can_air_turn) and player.input_direction != 0 and not player.crouching:
+	if (player.is_actually_on_floor() or player.in_water or player.has_wing or player.can_air_turn) and player.input_direction != 0 and not player.crouching:
 		player.direction = player.input_direction
 	var animation = get_animation_name()
 	player.sprite.speed_scale = 1
@@ -194,7 +194,7 @@ func get_animation_name() -> String:
 			elif abs(player.velocity.x) >= 5 and not player.is_actually_on_wall():
 				if player.in_water:
 					return "SwimAttack"
-				elif player.flight_meter > 0:
+				elif player.has_wing:
 					return "FlyAttack"
 				elif abs(player.velocity.x) < player.RUN_SPEED - 10:
 					return "WalkAttack"
@@ -205,7 +205,7 @@ func get_animation_name() -> String:
 		else:
 			if player.in_water:
 				return "SwimAttack"
-			elif player.flight_meter > 0:
+			elif player.has_wing:
 				return "FlyAttack"
 			else:
 				return "AirAttack"
@@ -223,14 +223,14 @@ func get_animation_name() -> String:
 			if abs(player.velocity.x) >= 5 and not player.is_actually_on_wall():
 				if player.in_water:
 					return "WaterCrouchMove"
-				elif player.flight_meter > 0:
+				elif player.has_wing:
 					return "WingCrouchMove"
 				else:
 					return "CrouchMove"
 			else:
 				if player.in_water:
 					return "WaterCrouch"
-				elif player.flight_meter > 0:
+				elif player.has_wing:
 					return "WingCrouch"
 				else:
 					return "Crouch"
@@ -240,7 +240,7 @@ func get_animation_name() -> String:
 		elif abs(player.velocity.x) >= 5 and not player.is_actually_on_wall():
 			if player.in_water:
 				return "WaterMove"
-			elif player.flight_meter > 0:
+			elif player.has_wing:
 				return "WingMove"
 			elif abs(player.velocity.x) < player.RUN_SPEED - 10:
 				return "Walk"
@@ -250,14 +250,14 @@ func get_animation_name() -> String:
 			if Global.player_action_pressed("move_up", player.player_id):
 				if player.in_water:
 					return "WaterLookUp"
-				elif player.flight_meter > 0:
+				elif player.has_wing:
 					return "WingLookUp"
 				else:
 					return "LookUp"
 			else:
 				if player.in_water:
 					return "WaterIdle"
-				elif player.flight_meter > 0:
+				elif player.has_wing:
 					return "WingIdle"
 				else:
 					return "Idle"
@@ -270,7 +270,7 @@ func get_animation_name() -> String:
 					return "SwimUp"
 			else:
 				return "SwimIdle"
-		elif player.flight_meter > 0:
+		elif player.has_wing:
 			if swim_up_meter > 0:
 				if player.bumping and player.can_bump_fly:
 					return "FlyBump"


### PR DESCRIPTION
This is more in line with how the star and hammer timers are. flight_meter is a timer in Player, and checking for it has been replaced with the new has_wing. I also switched handle_wing_flight from being done in _physics_process to after physics in _process, like hammer and star, since it only handles visuals. I think this might fix some visual bugs.