### PR TITLE
Make Podoboos only score points on axe when horizontally on screen

### DIFF
--- a/Scripts/Classes/Entities/Enemies/Podoboo.gd
+++ b/Scripts/Classes/Entities/Enemies/Podoboo.gd
@@ -48,7 +48,10 @@ func calculate_jump_height() -> float:
 const SMOKE_PARTICLE = preload("uid://d08nv4qtfouv1")
 
 func flag_die() -> void:
-	die()
+	if $VisibleOnScreenEnabler2D.is_on_screen():
+		die()
+	else:
+		queue_free()
 
 func die() -> void:
 	killed.emit()


### PR DESCRIPTION
When finishing a castle level, Podoboos would formerly score points from anywhere in the level; this change makes them only score points and play their death animation/sound if they're within the screen boundaries horizontally, otherwise they just despawn.

Note that the on-screen check uses their VisibleOnScreenEnabler2D, which has an ~infinite vertical range check, so they'll still die from below the screen:
<img width="512" height="473" alt="image" src="https://github.com/user-attachments/assets/a7bab622-9e00-4ce4-a78e-10332692fc56" />