### PR TITLE
Buzzy Beetle shell fixes

### DIFF
--- a/Scenes/Prefabs/Entities/Objects/BuzzyBeetleShell.tscn
+++ b/Scenes/Prefabs/Entities/Objects/BuzzyBeetleShell.tscn
@@ -92,12 +92,17 @@ one_way_collision = true
 
 [node name="VisibleOnScreenEnabler2D" type="VisibleOnScreenEnabler2D" parent="."]
 position = Vector2(0, -8)
+scale = Vector2(1, 0.987)
+rect = Rect2(-128, -128, 256, 256)
 
 [connection signal="killed" from="." to="GibSpawner" method="summon_gib"]
 [connection signal="area_entered" from="Hitbox" to="." method="on_area_entered"]
 [connection signal="hammer_player_hit" from="EnemyPlayerDetection" to="." method="die_from_hammer"]
+[connection signal="hammer_player_hit" from="EnemyPlayerDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="invincible_player_hit" from="EnemyPlayerDetection" to="." method="die_from_object"]
+[connection signal="invincible_player_hit" from="EnemyPlayerDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="player_hit" from="EnemyPlayerDetection" to="." method="on_player_hit"]
 [connection signal="player_stomped_on" from="EnemyPlayerDetection" to="." method="on_player_stomped_on"]
 [connection signal="moving_shell_entered" from="ShellDetection" to="." method="die_from_object"]
 [connection signal="block_bounced" from="BlockBouncingDetection" to="." method="block_bounced"]
+[connection signal="screen_exited" from="VisibleOnScreenEnabler2D" to="." method="queue_free"]


### PR DESCRIPTION
Fixed a few issues with Buzzy Beetle shells that don't occur with Koopa shells:
- Buzzy Beetle shells formerly would not despawn when offscreen, and would hit enemies right on the edge of the screen as they spawned.
- Buzzy Beetle shells formerly would not award points when killed with a Starman or Hammer.

All of the above issues were fixed by copying missing attributes from the Koopa shells' scenes.

Demo of the previously present issues:
https://github.com/user-attachments/assets/34de343b-4a60-44a2-b0bc-3a09046d2692

Demo after the fix:
https://github.com/user-attachments/assets/75128196-f347-42e8-8a2c-d5b44d198f69


