### PR TITLE
Fix sideways pipe hitbox collision

### DIFF
--- a/Scripts/Classes/Entities/PipeArea.gd
+++ b/Scripts/Classes/Entities/PipeArea.gd
@@ -114,6 +114,7 @@ func in_game() -> void:
 
 func run_player_check(player: Player) -> void:
 	# guzlad: Added support for characters with a hitbox height below 1.0 to enter pipes underwater
+	# SkyanUltra: Added distance check to prevent entering pipes from too low.
 	var distance = player.global_position.distance_to(hitbox.global_position)
 	if distance <= 6 and Global.player_action_pressed(get_input_direction(enter_direction), player.player_id) and (player.is_actually_on_floor() or enter_direction == 1):
 		can_enter = false


### PR DESCRIPTION
This fixes a bug where players would clip the top edge of a sideways pipe's hitbox and get counted as being on the floor despite being above the pipe, thus allowing them to get warped into the pipe from there. To avoid this, the sideways pipe's hitbox instead just gets offset to ground level where the pipe would reasonably appear, which prevents this issue from happening.