### PR TITLE
Add custom.py for reducing build export size

### DIFF
--- a/custom.py
+++ b/custom.py
@@ -1,0 +1,55 @@
+target = "template_release"
+debug_symbols = "no"
+optimize = "size"
+lto = "full"
+
+disable_3d = "yes"
+disable_physics_3d = "yes"
+disable_navigation_2d = "yes"
+disable_navigation_3d = "yes"
+disable_xr = "yes"
+accesskit = "no"
+
+# deprecated="no"  # Disables deprecated features. This breaks one of the extensions :/
+vulkan = "no"  # Disables the Vulkan driver (used in Forward+/Mobile Renderers)
+use_volk = "no"  # Disables more Vulkan stuff
+openxr = "no"  # Disables Virtual Reality/Augmented Reality stuff
+graphite = "no"  # Disables SIL Graphite smart fonts support
+# metal="yes"     # Uncomment this line when exporting to Mac
+
+
+module_astcenc_enabled = "no"
+module_basis_universal_enabled = "no"
+module_bcdec_enabled = "no"
+module_betsy_enabled = "no"
+betsy_export_templates = "no"
+module_bmp_enabled = "no"
+module_camera_enabled = "no"
+module_csg_enabled = "no"
+module_cvtt_enabled = "no"
+cvtt_export_template = "no"
+module_dds_enabled = "no"
+module_etcpak_enabled = "no"
+module_fbx_enabled = "no"
+module_gltf_enabled = "no"
+module_godot_physics_3d_enabled = "no"
+module_gridmap_enabled = "no"
+module_hdr_enabled = "no"
+module_jolt_physics_enabled = "no"
+module_ktx_enabled = "no"
+module_lightmapper_rd_enabled = "no"
+module_mbedtls_enabled = "no"
+module_meshoptimizer_enabled = "no"
+minimp3_extra_formats = "no"
+module_mobile_vr_enabled = "no"
+module_mono_enable = "no"
+module_navigation_2d_enabled = "no"
+module_navigation_3d_enabled = "no"
+module_objectdb_profiler_enabled = "no"
+module_openxr_enabled = "no"
+module_text_server_fb_enabled = "no"
+module_tga_enabled = "no"
+module_theora_enabled = "no"
+module_tinyexr_enabled = "no"
+module_webxr_enabled = "no"
+module_xatlas_unwrap_enabled = "no"


### PR DESCRIPTION
This adds a custom file for reducing the file size of release templates. This only removes stuff like the 3D parts of the engine and Vulkan-related modules in Godot which are safe to remove, so it shouldn't affect the game at all.

Using `scons platform=windows target=template_release profile=custom.py`, this reduces the final exe of the game from 71MB to 34MB!

We can get even more gains (to somewhere around 25MB) by using a custom build config file too, but the compiler crashes when I used it on Godot 4.6-dev. I'll try again when we're on a stable version of the engine.

This doesn't compress the `.pck` though, which is around 50MB. Most of these are audio files that we can probably compress later, or better yet maybe play the original Mario tracks with an AudioStreamGenerator so they don't take any space at all. I'll try that in the future. For now, the custom.py alone should be pretty good gains.

**Note:** Even though I'm 99% sure these changes are safe, it's worth playtesting the game with the custom build to make sure nothing is missing and all mods are working.

**PS**: The game crashes right now if you export the game without removing the mod loader addons in 4.6-dev4. This is a Godot issue in general and not related to custom builds.