### PR TITLE
Fixed marathon best saving logic + marathon results UI

### DIFF
--- a/Scenes/Prefabs/UI/MarathonResults.tscn
+++ b/Scenes/Prefabs/UI/MarathonResults.tscn
@@ -175,6 +175,7 @@ offset_right = 90.0
 offset_bottom = 32.5
 grow_horizontal = 2
 grow_vertical = 2
+has_speedrun_stuff = true
 
 [node name="LevelSelect" parent="." instance=ExtResource("8_orie5")]
 visible = false

--- a/Scripts/Classes/Singletons/SpeedrunHandler.gd
+++ b/Scripts/Classes/Singletons/SpeedrunHandler.gd
@@ -303,7 +303,7 @@ func run_finished() -> void:
 	if Global.current_game_mode == Global.GameMode.BOO_RACE:
 		pass
 	else:
-		var best := -1
+		var best: float = -1
 		if Global.current_game_mode == Global.GameMode.MARATHON_PRACTICE:
 			if is_warp_run:
 				best = best_level_any_times.get(str(Global.world_num) + "-" + str(Global.level_num), -1)
@@ -314,7 +314,6 @@ func run_finished() -> void:
 				best = marathon_best_any_time
 			else:
 				best = marathon_best_warpless_time
-		
 		if best <= 0 or best > timer:
 			if Global.current_game_mode == Global.GameMode.MARATHON_PRACTICE:
 				save_recording()


### PR DESCRIPTION
Getting a new best in marathon mode that doesn't shave off a second of time (i.e. if you went from a time of 17.54 to 17.10) will no longer be internally ignored and now gets properly saved. Along with that, the world select menu accessed from MarathonResults now uses the proper marathon tracker icons.