### PR TITLE
Fix config variation keys for level music

### DIFF
--- a/Scripts/Classes/Singletons/AudioManager.gd
+++ b/Scripts/Classes/Singletons/AudioManager.gd
@@ -263,6 +263,12 @@ func create_stream_from_json(json_path := "") -> AudioStream:
 					return AudioStreamOggVorbis.load_from_file(ResourceSetter.get_pure_resource_path(json_path))
 		elif path.contains("res://"):
 			return load(path)
+			
+	for i in Settings.file.visuals.resource_packs:
+		var new_path = $ResourceSetterNew.get_resource_pack_path(ResourceSetter.get_pure_resource_path(json_path), i)
+		if ResourceSetter.get_pure_resource_path(json_path) != new_path or $ResourceSetterNew.current_resource_pack == "":
+			$ResourceSetterNew.current_resource_pack = i
+			
 	var bgm_file = $ResourceSetterNew.get_variation_json(JSON.parse_string(FileAccess.open(ResourceSetter.get_pure_resource_path(json_path), FileAccess.READ).get_as_text()).variations).source
 	path = ResourceSetter.get_pure_resource_path(json_path.replace(json_path.get_file(), bgm_file))
 	var stream = null

--- a/Scripts/UI/ResourcePackConfigMenu.gd
+++ b/Scripts/UI/ResourcePackConfigMenu.gd
@@ -59,6 +59,7 @@ func update_json() -> void:
 func close() -> void:
 	ResourceSetter.cache.clear()
 	ResourceSetterNew.cache.clear()
+	AudioManager.current_level_theme = ""
 	Global.level_theme_changed.emit()
 	closed.emit()
 	clear_options()


### PR DESCRIPTION


https://github.com/user-attachments/assets/0ed229d9-4fcd-41fb-ad25-9fd1e25229dc


Previously, having config variations in a json for level music would prevent the song from playing...


Because AudioManager called get_variation_json directly instead of using get_resource, the current_resource_pack wasn't set. I proceeded to implement the worst fix possible because I couldn't get anything else to work😭