### PR TITLE
Variation system rewrite

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -208,7 +208,7 @@ func get_variation_json_new(json := {}, default := {}) -> Dictionary:
 		return json
 	if json.has("choices"):
 		is_random = true
-		var random_json = json.choices.pick_random()
+		var random_json = get_random_json(json.choices)
 		if random_json.has("link"):
 			return get_variation_json_new(json[random_json.link], default)
 		else:
@@ -261,7 +261,7 @@ func get_variation_json_old(json := {}) -> Dictionary:
 	
 	if json.has("choices"):
 		is_random = true
-		var random_json = json.choices.pick_random()
+		var random_json = get_random_json(json.choices)
 		if random_json.has("link"):
 			json = get_variation_json_old(json[random_json.get("link")])
 		else:
@@ -303,6 +303,13 @@ func get_variation_json_old(json := {}) -> Dictionary:
 				return get_variation_json_old(json[variation])
 	
 	return json
+
+func get_random_json(choices: Array) -> Dictionary:
+	var rng := RandomNumberGenerator.new()
+	var weights: PackedFloat32Array = []
+	for i in choices:
+		weights.append(i.get("weight", 1))
+	return choices[rng.rand_weighted(weights)]
 
 func get_pack_format(resource_pack := "") -> void:
 	pack_format = 0

--- a/Scripts/Parts/ResourcePackTemplateCreator.gd
+++ b/Scripts/Parts/ResourcePackTemplateCreator.gd
@@ -13,9 +13,10 @@ const base_info_json := {
 	"name": "New Pack",
 	"description": "Template, give me a description!",
 	"author": "Me, until you change it",
-	"version": "1.0"
-	}
-	
+	"version": "1.0",
+	"format": 0
+}
+
 const disallowed_files := ["bgm","ctex","json","fnt", "svg"]
 
 func create_template() -> void:
@@ -79,7 +80,7 @@ func create_template() -> void:
 	var pack_info_path = Global.config_path.path_join("resource_packs/new_pack/pack_info.json")
 	DirAccess.make_dir_recursive_absolute(pack_info_path.get_base_dir())
 	var file = FileAccess.open(pack_info_path, FileAccess.WRITE)
-	file.store_string(JSON.stringify(base_info_json, "\t"))
+	file.store_string(JSON.stringify(base_info_json, "\t", false))
 	file.close()
 	print("Done")
 	pack_created.emit()


### PR DESCRIPTION
Rewrites the variation checks to be more optimized.
A source is now checked for _first_ and then runs through every variation check if not found.
`default` is now the default variation key regardless of variation type.
If a source is not found, the latest default value will be used even if it does not exist within the current branch.
This negates the need to duplicate sources. For example, if 8-3 was to have a unique background, it'd be formatted like this:
>"default": {"source": "default.png"},
"World8": {
"Level3": {"source": "8-3.png"}
}

while the current system would require this:
> "World1": {"source": "default.png"},
"World8": {
"Level1": {"source": "default.png"},
"Level3": {"source": "8-3.png"}
}

In order to not break every current resource pack that was built with the old system in mind, a backporting system has been implemented.
The pack_info.json file now includes a `format` value.
Format 0 uses the old system, while format 1 uses the new system.
0 is the default if not specified.
The old variation code has also been cleaned up but still generally functions the same.