### PR TITLE
Fix wing powerup flap

### DIFF
--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -1059,7 +1059,7 @@ func handle_wing_flight(delta: float) -> void:
 	%Wing.offset = Vector2(wing_offset[0], wing_offset[1])
 	if flight_meter <= 0:
 		return
-	if actual_velocity_y() < 0:
+	if normal_state.swim_up_meter > 0:
 		%Wing.play("Flap")
 	else:
 		%Wing.play("Idle")


### PR DESCRIPTION
Since the wing flap animation was based just on velocity, there was a small bug where the animation appeared to "jolt" at the end. I changed it so its based on the swim_up_timer instead, which matches the swim animation and makes it so the flap only plays when you actually fly up.