### PR TITLE
Quick invincibility visual fix

### DIFF
--- a/Scenes/Prefabs/Entities/Player.tscn
+++ b/Scenes/Prefabs/Entities/Player.tscn
@@ -83,7 +83,7 @@ vec4 mode_1(vec4 colour)
     for (int i = 0; i < palette_count; i++)
 {
     float x_coord = (float(i) + 0.5) / palette_size;
-    float y_coord = (float(palette_idx)) / float(invincible_palette_size);
+    float y_coord = (float(palette_idx)) / float(palette_height);
 
     vec4 sampled = texture(player_palette, vec2(x_coord, y_coord));
 

--- a/Scripts/Classes/Entities/Player.gd
+++ b/Scripts/Classes/Entities/Player.gd
@@ -919,6 +919,7 @@ func handle_invincible_palette() -> void:
 	sprite.material.set_shader_parameter("mode", !Settings.file.visuals.rainbow_style)
 	sprite.material.set_shader_parameter("player_palette", $PlayerPalette.texture)
 	sprite.material.set_shader_parameter("palette_size", colour_palette.get_width())
+	sprite.material.set_shader_parameter("palette_height", POWER_STATES.size())
 	sprite.material.set_shader_parameter("invincible_palette", $InvinciblePalette.texture)
 	sprite.material.set_shader_parameter("invincible_palette_size", $InvinciblePalette.texture.get_height())
 	sprite.material.set_shader_parameter("palette_idx", POWER_STATES.find(power_state.state_name))


### PR DESCRIPTION
Powering up didn't properly update the index of color palette to change for extended invincibility palettes.  This fixes that and makes sure to update the palette height dynamically based on how many power states are defined for future proofing.