### PR TITLE
more checks for the player state detection gizmo + bugfixes

### DIFF
--- a/Scripts/Classes/Gizmos/ANDGate.gd
+++ b/Scripts/Classes/Gizmos/ANDGate.gd
@@ -11,15 +11,16 @@ var condition_filled := false
 
 func _ready() -> void:
 	if Global.level_editor_is_editing() == false:
-		update()
+		update.call_deferred()
 
 func input_added() -> void:
 	total_inputs += 1
 	update()
 
 func update() -> void:
-	if is_inside_tree(): #dunno why, but this line is needed fsr, guess we'll never know lmao
-		await get_tree().process_frame
+	#this line was causing a one frame delay in all scenarios, which is not very good
+	#if is_inside_tree():
+		#await get_tree().process_frame
 	total_inputs = clamp(total_inputs, 0, INF)
 	var test_condition = get_condition()
 	if test_condition != condition_filled:

--- a/Scripts/Classes/Gizmos/PlayerFlinger.gd
+++ b/Scripts/Classes/Gizmos/PlayerFlinger.gd
@@ -13,21 +13,27 @@ extends Node2D
 @export var update_player_direction := true
 
 var active := false
+var launched_this_frame := false
 
 func _physics_process(_delta: float) -> void:
 	if active:
 		launch()
+	launched_this_frame = false
 
 func turn_on() -> void:
 	active = true
+	launch() # necessary for zero frame pulses in certain scenarios
 
 func turn_off() -> void:
 	active = false
 
 func launch() -> void:
+	if launched_this_frame:
+		return
 	if get_tree():
 		for i: Player in get_tree().get_nodes_in_group("Players"):
 			i.has_flung = true
+			launched_this_frame = true
 			if additive:
 				i.velocity.y = i.velocity.y + upwards_speed*-100
 				if relative_to_direction:

--- a/Scripts/Classes/Gizmos/PlayerStateDetection.gd
+++ b/Scripts/Classes/Gizmos/PlayerStateDetection.gd
@@ -32,9 +32,9 @@ func _physics_process(_delta: float) -> void:
 			9:
 				run_check(player.direction == 1)
 			10:
-				run_check(player.velocity.x < 0)
+				run_check(player.velocity_direction == -1)
 			11:
-				run_check(player.velocity.x > 0)
+				run_check(player.velocity_direction == 1)
 
 func run_check(check := false) -> void:
 	if check:

--- a/Scripts/Classes/Gizmos/PlayerStateDetection.gd
+++ b/Scripts/Classes/Gizmos/PlayerStateDetection.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-@export_enum("On Floor", "On Wall", "On Ceiling", "Is Falling", "Is Small", "Is Big", "Is Fire", "Is Superball") var state_to_detect := 0
+@export_enum("On Floor", "On Wall", "On Ceiling", "Is Falling", "Is Small", "Is Big", "Is Fire", "Is Superball", "Is Facing Left", "Is Facing Right", "Is Going Left", "Is Going Right") var state_to_detect := 0
 
 signal turned_on
 signal turned_off
@@ -27,6 +27,14 @@ func _physics_process(_delta: float) -> void:
 				run_check(player.power_state.state_name == "Fire")
 			7:
 				run_check(player.power_state.state_name == "Superball")
+			8:
+				run_check(player.direction == -1)
+			9:
+				run_check(player.direction == 1)
+			10:
+				run_check(player.velocity.x < 0)
+			11:
+				run_check(player.velocity.x > 0)
 
 func run_check(check := false) -> void:
 	if check:


### PR DESCRIPTION
adds four more checks to the player state detection gizmo (note that facing a direction is different from going in that direction):
- is facing left?
- is facing right?
- is going left?
- is going right?

as well as two bugfixes:
- gates no longer have a one frame delay for no reason (while fixing the bug it was meant to fix
- flingers now activate under certain conditions where they wouldnt before (usually related to gates and triggers
<img width="329" height="242" alt="image" src="https://github.com/user-attachments/assets/c6caa3ee-2172-4f2a-b471-95f3f47096d8" />
