### PR TITLE
[Godot Mod Loader] Changed AutoLoads of the Mod Loader to use the file path instead of UIDs

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -32,8 +32,8 @@ buses/default_bus_layout="uid://bc65qkbkya885"
 
 [autoload]
 
-ModLoaderStore="*uid://jv5kxtsw7sfj"
-ModLoader="*uid://bd8npc3ai2vv3"
+ModLoaderStore="*res://addons/mod_loader/mod_loader_store.gd"
+ModLoader="*res://addons/mod_loader/mod_loader.gd"
 NewLevelBuilder="*res://Scenes/Prefabs/Autoload/NewLevelBuilder.gd"
 Global="*res://Scenes/Prefabs/Global.tscn"
 Settings="*res://Scenes/Prefabs/Autoload/Settings.tscn"


### PR DESCRIPTION
This changes the project file. Only changing the usage to UID that I DID NOT asked for.

Why is Godot like that? 