### PR TITLE
Fixed Gate gizmos infinite loop

### DIFF
--- a/Scripts/Classes/Gizmos/ANDGate.gd
+++ b/Scripts/Classes/Gizmos/ANDGate.gd
@@ -30,7 +30,7 @@ func input_added() -> void:
 	update.call_deferred()
 
 func update() -> void:
-	total_inputs = clamp(total_inputs, 0, INF)
+	total_inputs = clamp(total_inputs, 0, $SignalExposer.total_inputs)
 	var test_condition = get_condition()
 	if test_condition != condition_filled:
 		if test_condition == true:

--- a/Scripts/Classes/Gizmos/ANDGate.gd
+++ b/Scripts/Classes/Gizmos/ANDGate.gd
@@ -14,20 +14,31 @@ var condition_filled := false
 
 var checking := false
 
+var freeze_grab := 1024
+
 func _ready() -> void:
 	if Global.level_editor_is_editing() == false:
 		update.call_deferred()
+
+func _process(delta: float) -> void:
+	if (freeze_grab < 1024):
+		await get_tree().process_frame
+		freeze_grab = 1024
 
 func input_added() -> void:
 	total_inputs += 1
 	update.call_deferred()
 
 func update() -> void:
-	total_inputs = clamp(total_inputs, 0, $SignalExposer.total_inputs)
+	total_inputs = clamp(total_inputs, 0, INF)
 	var test_condition = get_condition()
-	print([total_inputs, $SignalExposer.total_inputs, ["AND", "OR", "NOT", "XOR"][type]])
 	if test_condition != condition_filled:
 		if test_condition == true:
+			freeze_grab -= 1
+			if (freeze_grab <= 0):
+				await get_tree().process_frame
+				$SignalExposer.explode()
+				return
 			condition_met.emit()
 		else:
 			condition_lost.emit()


### PR DESCRIPTION
Fun bug that freezes your game. You could make an infinite loop using two Gate gizmos that activated each other on the same frame. Here's an example:
<img width="245" height="269" alt="image" src="https://github.com/user-attachments/assets/34d6e857-0307-4fb8-bfff-e09bef50520c" />

To fix this, it uses a variable that gets reset every other frame if needed. If it gets decreased 1024 times in the same frame, one of the Gate gizmos explode. Bug found by Bellcarved on discord.