### PR TITLE
Sank sprites one pixel into the ground in the Challenge Results scenes

### DIFF
--- a/Scenes/Levels/ChallengeModeCastleResults.tscn
+++ b/Scenes/Levels/ChallengeModeCastleResults.tscn
@@ -7,6 +7,9 @@
 
 [node name="ChallengeModeResults" unique_id=1393486200 instance=ExtResource("1_vr3sy")]
 
+[node name="Yoshi" parent="." index="14" unique_id=227881632]
+position = Vector2(16, 1)
+
 [node name="LabelFontChanger" parent="." index="20" unique_id=1370610741 node_paths=PackedStringArray("labels")]
 labels = [NodePath("../Sprite2D/Sprite2D3/Score"), NodePath("../Sprite2D/Sprite2D3/Coins2"), NodePath("../Sprite2D/Sprite2D3/ScoreText"), NodePath("../Sprite2D/Sprite2D3/ScoreText/Target"), null, NodePath("../SpeechBubble/Your"), NodePath("../SpeechBubble/Your/Results"), NodePath("../SpeechBubble/Coins"), NodePath("../SpeechBubble/Score"), NodePath("../SpeechBubble/Score/ScoreLabel"), NodePath("../Label"), NodePath("../WorldLevel"), NodePath("../Label2")]
 

--- a/Scenes/Levels/ChallengeModeResults.tscn
+++ b/Scenes/Levels/ChallengeModeResults.tscn
@@ -51,7 +51,7 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector2(-96, 16), Vector2(-40, 16)]
+"values": [Vector2(-96, 17), Vector2(-40, 17)]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -794,7 +794,7 @@ autoplay = &"Main"
 speed_scale = 0.8
 
 [node name="Toad" type="AnimatedSprite2D" parent="." unique_id=130158692]
-position = Vector2(56, 0)
+position = Vector2(56, 1)
 sprite_frames = SubResource("SpriteFrames_woqpu")
 animation = &"1Idle"
 autoplay = "Idle"
@@ -982,7 +982,7 @@ metadata/_custom_type_script = "uid://dmtw1jesw1vl7"
 [node name="Yoshi" type="AnimatedSprite2D" parent="." unique_id=227881632]
 process_mode = 3
 visible = false
-position = Vector2(16, 0)
+position = Vector2(16, 1)
 sprite_frames = SubResource("SpriteFrames_21ujm")
 animation = &"1"
 autoplay = "1"


### PR DESCRIPTION
Makes Mario, Toad and Yoshi sink one pixel into the ground in the Challenge Results room, as they do pretty much everywhere else in the game.

This not only makes the visuals more consistent with the rest of the game, but allows for resource packs to offset those sprites to not clip into the ground elsewhere without inadvertently making them float off the ground in this room.