### PR TITLE
Added metadata for what item a Lakitu throws

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -337,14 +337,20 @@ func get_variation_json(json := {}) -> Dictionary:
 			var node_to_use = metadata_node
 			if node_to_use == null:
 				node_to_use = owner
-			var meta_value = str(node_to_use.get_meta(meta_name, "Default"))
-			if json[i].has(meta_value):
-				if json[i].get(meta_value).has("link"):
-					json = get_variation_json(json[i][json.get(meta_value).get("link")])
-				else:
-					json = get_variation_json(json[i][meta_value])
-				break
+			var meta_value = str(node_to_use.get_meta(meta_name, "Default")) if node_to_use != null else "Default"
+			var meta_json = null
 			
+			if json[i].has(meta_value):
+				meta_json = json[i].get(meta_value)
+			elif json[i].has("Default"):
+				meta_json = json[i].get("Default")
+			if meta_json != null:
+				if meta_json.has("link"):
+					json = get_variation_json(json[i][meta_json.get("link")])
+				else:
+					json = get_variation_json(meta_json)
+				break
+		
 	return json
 
 func get_config_file(resource_pack := "") -> void:

--- a/Scripts/Classes/Entities/Enemies/Lakitu.gd
+++ b/Scripts/Classes/Entities/Enemies/Lakitu.gd
@@ -29,6 +29,9 @@ func _ready() -> void:
 	$ThrowTimer.start()
 	lakitu_point = to_local(global_position)
 	get_parent().move_child(self, 0)
+	
+	var item_path = item.resource_path
+	set_meta("Item", item_path.right(-item_path.rfind("/") - 1).left(-5))
 
 func _process(_delta: float) -> void:
 	screen_center = get_viewport().get_camera_2d().get_screen_center_position()

--- a/Scripts/Classes/Entities/Enemies/Lakitu.gd
+++ b/Scripts/Classes/Entities/Enemies/Lakitu.gd
@@ -21,7 +21,11 @@ var can_enter := false
 @export var max_spiny_amount := 3
 
 static var spiny_amount := 0
-@export var item: PackedScene = null
+@export var item: PackedScene = null:
+	set(value):
+		item = value
+		set_meta_data()
+		
 @export var retreat_x := 3072
 
 func _ready() -> void:
@@ -29,9 +33,6 @@ func _ready() -> void:
 	$ThrowTimer.start()
 	lakitu_point = to_local(global_position)
 	get_parent().move_child(self, 0)
-	
-	var item_path = item.resource_path
-	set_meta("Item", item_path.right(-item_path.rfind("/") - 1).left(-5))
 
 func _process(_delta: float) -> void:
 	screen_center = get_viewport().get_camera_2d().get_screen_center_position()
@@ -103,3 +104,7 @@ func on_screen_entered() -> void:
 	add_to_group("Lakitus")
 	if get_tree().get_node_count_in_group("Lakitus") >= 2:
 		queue_free()
+
+func set_meta_data():
+	var item_path = item.resource_path
+	set_meta("Item", item_path.right(-item_path.rfind("/") - 1).left(-5))


### PR DESCRIPTION
The item selected for a Lakitu to throw is now also set in its metadata, allowing it to be referenced in resource packs. The item name is fetched from the scene file, without the .tscn.

This could be used to have the Throw animation vary depending on what is being thrown, for example