### PR TITLE
Added Sequence Variation Key

### DIFF
--- a/Scripts/Classes/Components/ResourceSetterNew.gd
+++ b/Scripts/Classes/Components/ResourceSetterNew.gd
@@ -21,6 +21,7 @@ enum ResourceMode {SPRITE_FRAMES, TEXTURE, AUDIO, RAW, FONT, THEME}
 static var cache := {}
 static var property_cache := {}
 static var active_flags := []
+static var sequences := {}
 
 var current_json_path := ""
 
@@ -30,7 +31,7 @@ static var pack_configs := {}
 
 var config_to_use := {}
 
-var is_random := false
+var is_variable := false
 
 signal updated
 
@@ -198,7 +199,7 @@ func get_resource(json_file: JSON) -> Resource:
 			Global.particle_override = json.get("particles", -1)
 			Global.extra_music_override = json.get("extra_bgm", "")
 			Global.liquid_override = json.get("liquid", -1)
-	if cache.has(json_file.resource_path) == false and use_cache and not is_random:
+	if cache.has(json_file.resource_path) == false and use_cache and not is_variable:
 		cache[json_file.resource_path] = resource
 	return resource
 
@@ -275,7 +276,7 @@ func get_variation_json(json := {}) -> Dictionary:
 			json = get_variation_json(json[campaign])
 	
 	if json.has("choices"):
-		is_random = true
+		is_variable = true
 		var idx := randi_range(0, json.choices.size() - 1)
 		if has_meta("RNGChoice"):
 			idx = get_meta("RNGChoice", -1)
@@ -286,6 +287,21 @@ func get_variation_json(json := {}) -> Dictionary:
 			json = get_variation_json(json[random_json.get("link")])
 		else:
 			json = get_variation_json(random_json)
+			
+	if json.has("sequence"):
+		is_variable = true
+		var idx := 0
+		if has_meta("SequencePos"):
+			idx = get_meta("SequencePos", -1)
+		else:
+			idx = sequences.get(json_path, -1) + 1
+			set_meta("SequencePos", idx)
+			sequences[json_path] = idx
+		var sequence_json = json.sequence[posmod(idx, json.sequence.size())]
+		if sequence_json.has("link"):
+			json = get_variation_json(json[sequence_json.get("link")])
+		else:
+			json = get_variation_json(sequence_json)
 	
 	var world = "World" + str(Global.world_num)
 	if force_properties.has("World"):
@@ -347,7 +363,7 @@ func get_variation_json(json := {}) -> Dictionary:
 	
 	var meta_data_keys := json.keys().filter(func(key): return key.contains("Metadata"))
 	if meta_data_keys.is_empty() == false:
-		is_random = true
+		is_variable = true
 		for i in meta_data_keys:
 			var meta_name = i.get_slice(":", 1)
 			var node_to_use = metadata_node
@@ -409,6 +425,7 @@ static func clear_cache() -> void:
 	cache.clear()
 	active_flags.clear()
 	property_cache.clear()
+	sequences.clear()
 
 func load_image_from_path(path := "") -> Texture2D:
 	if path.contains("res://"):


### PR DESCRIPTION
Allows resource packs to use a variation key named "Sequence" which takes a list of variations to be loaded in the chosen order and looping at the end of the sequence. Sequences are reset per level and sublevel, and the sequence position is preserved when a Koopa retreats into its shell for example