### PR TITLE
Added wing metadata

### DIFF
--- a/Scenes/Parts/Wing.tscn
+++ b/Scenes/Parts/Wing.tscn
@@ -35,10 +35,11 @@ script = ExtResource("2_io3xw")
 do_offset = false
 metadata/_custom_type_script = "uid://caq1qiwmy0mox"
 
-[node name="ResourceSetterNew" type="Node" parent="." unique_id=1011792679 node_paths=PackedStringArray("node_to_affect")]
+[node name="ResourceSetterNew" type="Node" parent="." unique_id=1011792679 node_paths=PackedStringArray("node_to_affect", "metadata_node")]
 process_mode = 3
 script = ExtResource("3_r7kgt")
 node_to_affect = NodePath("..")
 property_name = "sprite_frames"
 json_path = "res://Assets/Sprites/Items/Wings.json"
+metadata_node = NodePath("..")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"

--- a/Scenes/Prefabs/Entities/Enemies/GreenKoopaParaTroopa.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/GreenKoopaParaTroopa.tscn
@@ -7,6 +7,7 @@ winged = true
 
 [node name="Wing" parent="Sprite" parent_id_path=PackedInt32Array(1845041467) index="1" unique_id=1386975840]
 visible = true
+metadata/WingType = "GreenKoopa"
 
 [node name="BasicEnemyMovement" parent="." index="14" unique_id=1775651446]
 bounce_height = -250

--- a/Scenes/Prefabs/Entities/Enemies/GreenKoopaTroopa.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/GreenKoopaTroopa.tscn
@@ -84,6 +84,7 @@ position = Vector2(-8, 3)
 autoplay = "Flap"
 frame_progress = 0.0
 flip_h = true
+metadata/WingType = "GreenKoopa"
 
 [node name="DeathSprite" type="AnimatedSprite2D" parent="." unique_id=81522450]
 visible = false
@@ -197,8 +198,8 @@ metadata/_custom_type_script = "uid://maqpreddu5kg"
 [connection signal="player_stomped_on" from="EnemyPlayerDetection" to="LevelPersistance" method="set_as_active" unbinds=1]
 [connection signal="fireball_hit" from="FireballDetection" to="." method="die_from_object"]
 [connection signal="fireball_hit" from="FireballDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
-[connection signal="block_bounced" from="BlockBouncingDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="block_bounced" from="BlockBouncingDetection" to="." method="block_bounced" unbinds=1]
+[connection signal="block_bounced" from="BlockBouncingDetection" to="ScoreNoteSpawner" method="spawn_note" binds= [200]]
 [connection signal="moving_shell_entered" from="ShellDetection" to="." method="die_from_object"]
 [connection signal="icicle_detected" from="IcicleDetection" to="." method="die_from_object"]
 [connection signal="explosion_entered" from="ExplosionDetection" to="." method="die_from_object"]

--- a/Scenes/Prefabs/Entities/Enemies/GreenParaKoopaHori.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/GreenParaKoopaHori.tscn
@@ -7,6 +7,9 @@
 [node name="GreenKoopaTroopa" unique_id=287819354 instance=ExtResource("1_pd6rg")]
 metadata/fly_2 = true
 
+[node name="Wing" parent="Sprite" parent_id_path=PackedInt32Array(1845041467) index="1" unique_id=1386975840]
+metadata/WingType = "GreenKoopaHori"
+
 [node name="LevelEditorVisibleNode" type="Node2D" parent="." index="18" unique_id=1769048555]
 script = ExtResource("2_6kidr")
 metadata/_custom_type_script = "uid://cpwloakvp672a"

--- a/Scenes/Prefabs/Entities/Enemies/RedKoopaParaTroopa.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/RedKoopaParaTroopa.tscn
@@ -10,6 +10,7 @@ winged = true
 [node name="Wing" parent="Sprite" parent_id_path=PackedInt32Array(1845041467) index="1" unique_id=1386975840]
 visible = true
 frame_progress = 0.539258
+metadata/WingType = "RedKoopa"
 
 [node name="Node2D" type="Node2D" parent="." index="15" unique_id=118285782]
 script = ExtResource("2_7ppsp")

--- a/Scenes/Prefabs/Entities/Enemies/RedKoopaTroopa.tscn
+++ b/Scenes/Prefabs/Entities/Enemies/RedKoopaTroopa.tscn
@@ -9,6 +9,9 @@ metadata/is_red = true
 [node name="SpriteSetter" parent="Sprite" parent_id_path=PackedInt32Array(1845041467) index="0" unique_id=1746108447]
 json_path = "res://Assets/Sprites/Enemies/RedKoopaTroopa.json"
 
+[node name="Wing" parent="Sprite" parent_id_path=PackedInt32Array(1845041467) index="1" unique_id=1386975840]
+metadata/WingType = "RedKoopa"
+
 [node name="ShellSetter" parent="DeathSprite" parent_id_path=PackedInt32Array(81522450) index="0" unique_id=393858697]
 json_path = "res://Assets/Sprites/Enemies/RedKoopaShell.json"
 

--- a/Scenes/Prefabs/Entities/Player.tscn
+++ b/Scenes/Prefabs/Entities/Player.tscn
@@ -574,6 +574,7 @@ shape = SubResource("RectangleShape2D_xy8gq")
 [node name="Wings" type="Node2D" parent="SpriteScaleJoint/Sprite" unique_id=1765238875]
 unique_name_in_owner = true
 visible = false
+metadata/WingType = "Player"
 
 [node name="Wing" type="AnimatedSprite2D" parent="SpriteScaleJoint/Sprite/Wings" unique_id=220386174]
 unique_name_in_owner = true
@@ -583,12 +584,13 @@ sprite_frames = SubResource("SpriteFrames_uwhl4")
 animation = &"Idle"
 flip_h = true
 
-[node name="ResourceSetterNew" type="Node" parent="SpriteScaleJoint/Sprite/Wings/Wing" unique_id=1491180846 node_paths=PackedStringArray("node_to_affect")]
+[node name="ResourceSetterNew" type="Node" parent="SpriteScaleJoint/Sprite/Wings/Wing" unique_id=1491180846 node_paths=PackedStringArray("node_to_affect", "metadata_node")]
 process_mode = 3
 script = ExtResource("25_cekpg")
 node_to_affect = NodePath("..")
 property_name = "sprite_frames"
 json_path = "res://Assets/Sprites/Items/Wings.json"
+metadata_node = NodePath("../..")
 metadata/_custom_type_script = "uid://cbal8ms2oe1ik"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="SpriteScaleJoint/Sprite/Wings" unique_id=305580541]


### PR DESCRIPTION
Wings now have metadata associated with what entity they are attached to, allowing them to be further customized through resource packs.

The accepted values are "Player", "GreenKoopa", "GreenKoopaHori" and "RedKoopa", and is easy to expand on if any new winged enemies are added in the future