### PR TITLE
Updated .gitignore again for Godot Mod Loader (GML)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@
 /android/
 Exports/
 
-# SMB1R specific ignores
+# GML specific ignores
 /mods
 /mods-unpacked
+/custom_objects
+/custom_objects-unpacked
+
+# SMB1R specific ignores
 Assets/LevelGuides
 addons/discord-rpc-gd/bin/windows/~discord_game_sdk_binding_debug.dll
 godotgif/bin/~godotgif.windows.template_debug.x86_64.dll


### PR DESCRIPTION
Added another set of ignores for the mod loader in the editor. Unless I missed something, I think that's all of them now. The `mod-hooks.zip` file is not generated in the editor.