### PR TITLE
Made Paratroopa animations play immediately upon loaded

### DIFF
--- a/Scripts/Classes/Entities/Enemies/KoopaTroopa.gd
+++ b/Scripts/Classes/Entities/Enemies/KoopaTroopa.gd
@@ -15,9 +15,9 @@ var times_kicked := 0 ## For anti-infinite scoring in Challenge mode
 func _ready() -> void:
 	if has_meta("fly_2"):
 		fly_wave = 0
-	else:
-		if winged:
-			play_animation("Hop")
+	if winged:
+		if has_meta("is_red") or has_meta("fly_2"): play_animation("Fly")
+		else: play_animation("Hop")
 
 func _physics_process(delta: float) -> void:
 	if winged and (has_meta("is_red") or has_meta("fly_2")):


### PR DESCRIPTION
Immediately plays the Fly animation of Paratroopas so they can be differentiated in the level editor when given different sprites through resource packs

This makes the behavior consistent with the Hop animation of regular Green Paratroopas

<img width="648" height="451" alt="image" src="https://github.com/user-attachments/assets/0cdc6add-6dc2-47b9-9d26-0e76c031f879" />
